### PR TITLE
Use anchors and doc layout

### DIFF
--- a/ref/general/codewind-kabanero-collections.adoc
+++ b/ref/general/codewind-kabanero-collections.adoc
@@ -1,10 +1,10 @@
-:page-layout: general-reference
+:page-layout: doc
 :page-doc-category: Reference
 :page-title: Using Kabanero Collections in Codewind
 :linkattrs:
 = Using Kabanero Collections in Codewind
 
-== Prerequisites
+== [#prerequisites]#Prerequisites#
 * https://eclipse.com/codewind[Codewind for VS Code or Eclipse v0.3.0 or later]
 * https://www.docker.com/get-started[Docker]
 * https://appsody.dev/docs/getting-started/installation[Appsody]
@@ -12,7 +12,7 @@
 ** Follow the instructions `Installing the Appsody Extension on Codewind` and `Optional: Using the Same Appsody Configuration Between Local CLI and Codewind` in the README.md file
 
 
-== Replace the default templates with the Kabanero Collections templates
+== [#templates]#Replace the default templates with the Kabanero Collections templates#
 Now that your local Appsody CLI points to the Appsody Extension, you can modify the repo's with the standard repo commands. 
 
 . First you will need to add the https://github.com/kabanero-io/collections[Kabanero Collections Repository]:
@@ -30,7 +30,7 @@ appsody repo remove appsodyhub
 appsody repo remove experimental
 ----
 
-== Create a project from a Kabanero Collection
+== [#createProject]#Create a project from a Kabanero Collection#
 Once the Kabanero templates have been added, you can create a project like you normally would in Codewind.
 
 * VS Code 

--- a/ref/general/codewind-kabanero-collections.adoc
+++ b/ref/general/codewind-kabanero-collections.adoc
@@ -2,9 +2,11 @@
 :page-doc-category: Reference
 :page-title: Using Kabanero Collections in Codewind
 :linkattrs:
+:sectanchors:
+
 = Using Kabanero Collections in Codewind
 
-== [#prerequisites]#Prerequisites#
+== Prerequisites
 * https://eclipse.com/codewind[Codewind for VS Code or Eclipse v0.3.0 or later]
 * https://www.docker.com/get-started[Docker]
 * https://appsody.dev/docs/getting-started/installation[Appsody]
@@ -12,7 +14,7 @@
 ** Follow the instructions `Installing the Appsody Extension on Codewind` and `Optional: Using the Same Appsody Configuration Between Local CLI and Codewind` in the README.md file
 
 
-== [#templates]#Replace the default templates with the Kabanero Collections templates#
+== Replace the default templates with the Kabanero Collections templates
 Now that your local Appsody CLI points to the Appsody Extension, you can modify the repo's with the standard repo commands. 
 
 . First you will need to add the https://github.com/kabanero-io/collections[Kabanero Collections Repository]:
@@ -30,7 +32,7 @@ appsody repo remove appsodyhub
 appsody repo remove experimental
 ----
 
-== [#createProject]#Create a project from a Kabanero Collection#
+== Create a project from a Kabanero Collection
 Once the Kabanero templates have been added, you can create a project like you normally would in Codewind.
 
 * VS Code 

--- a/ref/general/collection-building.adoc
+++ b/ref/general/collection-building.adoc
@@ -1,8 +1,8 @@
-:page-layout: general-reference
+:page-layout: doc
 :page-doc-category: Reference
 :page-title: Building a Kabanero collection locally
 :linkattrs:
-= Building the collections locally
+= [#localBuild]#Building the collections locally#
 
 . Clone the collections repository and create a new copy of it in your git organization
 +
@@ -108,6 +108,6 @@ git push --tags
 +
 This will trigger another Travis build that will also generate a Git Release and push the images to the image repository.
 
-== Need help?
+== [#help]#Need help?#
 If you have a question that you can't find an answer to, we would also like to hear about that too.
 You can reach out to the community for assistance on the https://ibm-cloud-tech.slack.com/messages/CJZCYTD0Q[Kabanero Slack channel, window="_blank"].

--- a/ref/general/collection-building.adoc
+++ b/ref/general/collection-building.adoc
@@ -2,6 +2,7 @@
 :page-doc-category: Reference
 :page-title: Building a Kabanero collection locally
 :linkattrs:
+:sectanchors:
 = Building the collections locally
 
 . Clone the collections repository and create a new copy of it in your git organization
@@ -108,6 +109,6 @@ git push --tags
 +
 This will trigger another Travis build that will also generate a Git Release and push the images to the image repository.
 
-== [#help]#Need help?#
+== Need help?
 If you have a question that you can't find an answer to, we would also like to hear about that too.
 You can reach out to the community for assistance on the https://ibm-cloud-tech.slack.com/messages/CJZCYTD0Q[Kabanero Slack channel, window="_blank"].

--- a/ref/general/collection-building.adoc
+++ b/ref/general/collection-building.adoc
@@ -2,7 +2,7 @@
 :page-doc-category: Reference
 :page-title: Building a Kabanero collection locally
 :linkattrs:
-= [#localBuild]#Building the collections locally#
+= Building the collections locally
 
 . Clone the collections repository and create a new copy of it in your git organization
 +

--- a/ref/general/collection-management.adoc
+++ b/ref/general/collection-management.adoc
@@ -2,6 +2,7 @@
 :page-doc-category: Reference
 :page-title: Kabanero Collections Overview
 :linkattrs:
+:sectanchors:
 
 The Kabanero project provides solution architects with the ability to manage  integrated collections. Kabanero organizes artifacts into a collection that specifies an Appsody stack, pipelines based on Tekton with “Build Task Definitions”.
 

--- a/ref/general/collection-management.adoc
+++ b/ref/general/collection-management.adoc
@@ -1,4 +1,4 @@
-:page-layout: general-reference
+:page-layout: doc
 :page-doc-category: Reference
 :page-title: Kabanero Collections Overview
 :linkattrs:

--- a/ref/general/docs-welcome.adoc
+++ b/ref/general/docs-welcome.adoc
@@ -1,9 +1,9 @@
-:page-layout: general-reference
+:page-layout: doc
 :page-title: Welcome to Docs
 
 = Welcome to the Kabanero Docs
 
-== Kabanero
+== [#kabanero]#Kabanero#
 
 Kabanero is an open source project that brings together foundational open source technologies into a modern microservices-based framework. Kabanero provides an end-to-end solution that enables you to architect, build, deploy, and manage the lifecycle of Kubernetes-based applications with more speed than ever.
 

--- a/ref/general/docs-welcome.adoc
+++ b/ref/general/docs-welcome.adoc
@@ -1,9 +1,10 @@
 :page-layout: doc
 :page-title: Welcome to Docs
+:sectanchors:
 
 = Welcome to the Kabanero Docs
 
-== [#kabanero]#Kabanero#
+== Kabanero
 
 Kabanero is an open source project that brings together foundational open source technologies into a modern microservices-based framework. Kabanero provides an end-to-end solution that enables you to architect, build, deploy, and manage the lifecycle of Kubernetes-based applications with more speed than ever.
 

--- a/ref/general/hello-world-appsody-codewind.adoc
+++ b/ref/general/hello-world-appsody-codewind.adoc
@@ -2,16 +2,17 @@
 :page-doc-category: Reference
 :page-title: Appsody Hello World on Codewind
 :linkattrs:
+:sectanchors:
 = Appsody Hello World on Codewind
 
-== [#prerequisites]#Prerequisites#
+== Prerequisites
 . https://www.eclipse.org/codewind/installlocally.html[Codewind] on Visual Studio Code or Eclipse
 . https://appsody.dev/docs/getting-started/installation[Appsody]
 . https://github.com/kabanero-io/appsodyExtension[Appsody Extension for Codewind]
 
-== [#vsCode]#Getting started with VS Code#
+== Getting started with VS Code
 
-=== [#vsCodeAppsody]#Creating a Java MicroProfile appsody Project#
+=== Creating a Java MicroProfile appsody Project
 In VS Code open the command palette and navigate to the option `Codewind: Create New Project`. 
 Select the Appsody Java MicroProfile template, give it a name and press enter. Navigate to the `Explorer` view. 
 In the `Explorer` view keep expanding the Codewind section until the project you created is visible. 
@@ -22,9 +23,9 @@ Other built in endpoints are described on the bottom of the https://github.com/a
 
 *NOTE:* The project might still be `starting` and you'll need to wait for it to be running.
 
-== [#eclipse]#Getting started with Eclispe#
+== Getting started with Eclispe
 
-=== [#eclipseAppsody]#Creating a Java MicroProfile appsody Project#
+=== Creating a Java MicroProfile appsody Project
 Open up the Codwind Explorer in your Eclipse workspace by clicking `Window -> Show View -> Other... -> Codewind -> Codewind Explorer`.
 Right click on the `Local Projects` under `Codewind` and select `New Project`. Select the Appsody Java MicroProfile template, give it a name and create it.
 Now underneath your `Codewind -> Local Projects`, there should be your project. 
@@ -35,16 +36,16 @@ Other built in endpoints are described on the bottom of the https://github.com/a
 
 *NOTE:* The project might still be `starting` and you'll need to wait for it to be running. Also you might need to refresh the project explorer to see the contents of your project directory.
 
-== [#helloWorld]#Hello World#
+== Hello World
 
-=== [#createIndex]#Create the index.html#
+=== Create the index.html
 Right-click on the appsody project and chose the option to `Open Folder as Workspace`. In the project workspace, navigate to `src/main/webapp/` and create a new file there called `index.html`.
 Open the file and add `Hello World`. Save the file and click the icon to open the app in your web browser again. You should see a webpage with `Hello World`. Now you can go back to the file and change it, save it, and then refresh the webpage.
 The webpage will now be displaying your change. 
 
 While this is only a basic Hello World html file, this same process goes for any changes in the project you want to make.
 
-== [#debugging]#Debugging#
+== Debugging
 You can debug these applications as you would any other Codewind project. 
 
 Find more info on debugging Codewind applications in VS Code https://www.eclipse.org/codewind/mdt-vsc-commands-restart-and-debug.html[here] and debugging in Eclipse https://www.eclipse.org/codewind/mdteclipsedebugproject.html[here]

--- a/ref/general/hello-world-appsody-codewind.adoc
+++ b/ref/general/hello-world-appsody-codewind.adoc
@@ -1,17 +1,17 @@
-:page-layout: general-reference
+:page-layout: doc
 :page-doc-category: Reference
 :page-title: Appsody Hello World on Codewind
 :linkattrs:
 = Appsody Hello World on Codewind
 
-== Prerequisites
+== [#prerequisites]#Prerequisites#
 . https://www.eclipse.org/codewind/installlocally.html[Codewind] on Visual Studio Code or Eclipse
 . https://appsody.dev/docs/getting-started/installation[Appsody]
 . https://github.com/kabanero-io/appsodyExtension[Appsody Extension for Codewind]
 
-== Getting started with VS Code
+== [#vsCode]#Getting started with VS Code#
 
-=== Creating a Java MicroProfile appsody Project
+=== [#vsCodeAppsody]#Creating a Java MicroProfile appsody Project#
 In VS Code open the command palette and navigate to the option `Codewind: Create New Project`. 
 Select the Appsody Java MicroProfile template, give it a name and press enter. Navigate to the `Explorer` view. 
 In the `Explorer` view keep expanding the Codewind section until the project you created is visible. 
@@ -22,9 +22,9 @@ Other built in endpoints are described on the bottom of the https://github.com/a
 
 *NOTE:* The project might still be `starting` and you'll need to wait for it to be running.
 
-== Getting started with Eclispe
+== [#eclipse]#Getting started with Eclispe#
 
-=== Creating a Java MicroProfile appsody Project
+=== [#eclipseAppsody]#Creating a Java MicroProfile appsody Project#
 Open up the Codwind Explorer in your Eclipse workspace by clicking `Window -> Show View -> Other... -> Codewind -> Codewind Explorer`.
 Right click on the `Local Projects` under `Codewind` and select `New Project`. Select the Appsody Java MicroProfile template, give it a name and create it.
 Now underneath your `Codewind -> Local Projects`, there should be your project. 
@@ -35,16 +35,16 @@ Other built in endpoints are described on the bottom of the https://github.com/a
 
 *NOTE:* The project might still be `starting` and you'll need to wait for it to be running. Also you might need to refresh the project explorer to see the contents of your project directory.
 
-== Hello World
+== [#helloWorld]#Hello World#
 
-=== Create the index.html
+=== [#createIndex]#Create the index.html#
 Right-click on the appsody project and chose the option to `Open Folder as Workspace`. In the project workspace, navigate to `src/main/webapp/` and create a new file there called `index.html`.
 Open the file and add `Hello World`. Save the file and click the icon to open the app in your web browser again. You should see a webpage with `Hello World`. Now you can go back to the file and change it, save it, and then refresh the webpage.
 The webpage will now be displaying your change. 
 
 While this is only a basic Hello World html file, this same process goes for any changes in the project you want to make.
 
-== Debugging
+== [#debugging]#Debugging#
 You can debug these applications as you would any other Codewind project. 
 
 Find more info on debugging Codewind applications in VS Code https://www.eclipse.org/codewind/mdt-vsc-commands-restart-and-debug.html[here] and debugging in Eclipse https://www.eclipse.org/codewind/mdteclipsedebugproject.html[here]

--- a/ref/general/installing-dev-tools.adoc
+++ b/ref/general/installing-dev-tools.adoc
@@ -2,9 +2,10 @@
 :page-doc-category: Installation
 :page-title: Installing Codewind in VS Code or Eclipse
 :linkattrs:
+:sectanchors:
 These instructions explain how you can install Codewind for two IDEs: VS Code and Eclipse. 
 
-== [#vsCodeInstall]#Installing Codewind for VS Code#
+== Installing Codewind for VS Code
 The Codewind installation includes two steps:
 
 . The VS Code extension installs when you install Codewind from the VS Code Marketplace or when you install by searching in the "VS Code Extensions" view.
@@ -16,10 +17,10 @@ The following Codewind images are pulled. These images together form the Codewin
 * `eclipse/codewind-performance-amd64`
 * `eclipse/codewind-pfe-amd64`
 
-=== [#usingCodewindVsCode]#Using Codewind#
+=== Using Codewind
 When the installation is complete, the extension is ready to use, and you are prompted to open the Codewind workspace. You can open the codewind-workspace or a project within the workspace as your VS Code workspace. For more information, see https://www.eclipse.org/codewind/mdt-vsc-getting-started.html[Getting started: Codewind for VS Code, window="_blank"].
 
-=== [#workingWorkspacesVsCode]#Working workspaces#
+=== Working workspaces
 Codewind creates the Codewind workspace on your system. The Codewind workspace is where Codewind expects to find your projects and where Codewind stores its metadata. 
 
 * On macOS and Linux, the workspace folder is `~/codewind-workspace`. 
@@ -27,7 +28,7 @@ Codewind creates the Codewind workspace on your system. The Codewind workspace i
 
 When Codewind creates a new project, it is created in the Codewind workspace. If you want to add an existing project to Codewind, first copy it into the Codewind workspace.
 
-=== [#updatingCodewindVsCode]#Updating the Codewind plug-in#
+=== Updating the Codewind plug-in
 Update your Codewind plug-in without unintalling the extension. 
 
 . Go to the *Extensions* view in VS Code
@@ -39,10 +40,10 @@ Update your Codewind plug-in without unintalling the extension.
 * If an older version of Codewind is installed and running, a message asks you to update the older version. Click *OK,* and Codewind stops automatically, and new images begin to download
 . Wait for the Codewind installation to complete. Codewind starts and is ready to use
 
-=== [#removingContainersVsCode]#Removing containers and images#
+=== Removing containers and images
 To remove Codewind, see https://www.eclipse.org/codewind/mdt-vsc-uninstall.html[Uninstalling Codewind from VS Code, window="_blank"].
 
-=== [#troubleshootingVsCode]#Troubleshooting# 
+=== Troubleshooting
 
 * Reinitiating the Codewind installation
 ** If you don't click "Install" when the "Install" prompt first appears, you can access the notification again. 
@@ -56,7 +57,7 @@ For more information about troubleshooting Codewind, see the https://www.eclipse
 
 '''
 
-== [#installingCodewindEclipse]#Installing Codewind for Eclipse#
+== Installing Codewind for Eclipse
 The Codewind installation includes two steps and 1 optional step:
 
 . The Eclipse plug-in installs when you install Codewind from the Eclipse Marketplace or when you install by searching in the "Eclipse Extensions" view.
@@ -69,11 +70,11 @@ The following images are pulled. These images together form the Codewind back en
 * `eclipse/codewind-performance-amd64`
 * `eclipse/codewind-pfe-amd64`
 
-=== [#usingCodewindEclipse]#Using Codewind#
+=== Using Codewind
 When the installation is complete, the extension is ready to use, and you are prompted to open the Codewind workspace.
 You can open the codewind-workspace or a project within the workspace as your Eclipse workspace. For more information, see https://www.eclipse.org/codewind/mdteclipsegettingstarted.html[Getting started: Codewind for Eclipse, window="_blank"]
 
-=== [#workingWorkspacesEclipse]#Working with workspaces# 
+=== Working with workspaces
 Codewind creates the Codewind workspace on your system. The Codewind workspace is where Codewind expects to find your projects and where Codewind stores its metadata.
 
 * On macOS and Linux, the workspace folder is `~/codewind-workspace`. 
@@ -81,7 +82,7 @@ Codewind creates the Codewind workspace on your system. The Codewind workspace i
 
 When Codewind creates a new project, it is created in the Codewind workspace. If you want to add an existing project to Codewind, first copy it into the Codewind workspace.
 
-=== [#updateingCodewindEclipse]#Updating the Codewind plug-in#
+=== Updating the Codewind plug-in
 Update the Codewind Eclipse plug-in to the latest version.
 
 . From Eclipse, go to *Help > About Eclipse IDE*
@@ -94,8 +95,8 @@ Update the Codewind Eclipse plug-in to the latest version.
 . Click *OK* in the *Codewind Update* window that states that the older version of Codewind will be removed, and the newer version will be started
 . After Codewind updates, the *Codewind Explorer* view appears with your projects
 
-=== [#removingContainersEclipse]#Removing containers and images#
+=== Removing containers and images
 To remove Codewind, see https://www.eclipse.org/codewind/mdteclipseuninstall.html[Uninstalling Codewind from Eclipse, window="_blank"].
 
-=== [#troubleshootingEclipse]#Troubleshooting#
+=== Troubleshooting
 To troubleshoot Codewind, see the https://www.eclipse.org/codewind/troubleshooting.html[Codewind Troubleshooting page, window="_blank"].

--- a/ref/general/installing-dev-tools.adoc
+++ b/ref/general/installing-dev-tools.adoc
@@ -1,10 +1,10 @@
-:page-layout: general-reference
+:page-layout: doc
 :page-doc-category: Installation
 :page-title: Installing Codewind in VS Code or Eclipse
 :linkattrs:
 These instructions explain how you can install Codewind for two IDEs: VS Code and Eclipse. 
 
-== Installing Codewind for VS Code
+== [#vsCodeInstall]#Installing Codewind for VS Code#
 The Codewind installation includes two steps:
 
 . The VS Code extension installs when you install Codewind from the VS Code Marketplace or when you install by searching in the "VS Code Extensions" view.
@@ -16,10 +16,10 @@ The following Codewind images are pulled. These images together form the Codewin
 * `eclipse/codewind-performance-amd64`
 * `eclipse/codewind-pfe-amd64`
 
-=== Using Codewind
+=== [#usingCodewindVsCode]#Using Codewind#
 When the installation is complete, the extension is ready to use, and you are prompted to open the Codewind workspace. You can open the codewind-workspace or a project within the workspace as your VS Code workspace. For more information, see https://www.eclipse.org/codewind/mdt-vsc-getting-started.html[Getting started: Codewind for VS Code, window="_blank"].
 
-=== Working workspaces
+=== [#workingWorkspacesVsCode]#Working workspaces#
 Codewind creates the Codewind workspace on your system. The Codewind workspace is where Codewind expects to find your projects and where Codewind stores its metadata. 
 
 * On macOS and Linux, the workspace folder is `~/codewind-workspace`. 
@@ -27,7 +27,7 @@ Codewind creates the Codewind workspace on your system. The Codewind workspace i
 
 When Codewind creates a new project, it is created in the Codewind workspace. If you want to add an existing project to Codewind, first copy it into the Codewind workspace.
 
-=== Updating the Codewind plug-in
+=== [#updatingCodewindVsCode]#Updating the Codewind plug-in#
 Update your Codewind plug-in without unintalling the extension. 
 
 . Go to the *Extensions* view in VS Code
@@ -39,10 +39,10 @@ Update your Codewind plug-in without unintalling the extension.
 * If an older version of Codewind is installed and running, a message asks you to update the older version. Click *OK,* and Codewind stops automatically, and new images begin to download
 . Wait for the Codewind installation to complete. Codewind starts and is ready to use
 
-=== Removing containers and images
+=== [#removingContainersVsCode]#Removing containers and images#
 To remove Codewind, see https://www.eclipse.org/codewind/mdt-vsc-uninstall.html[Uninstalling Codewind from VS Code, window="_blank"].
 
-=== Troubleshooting 
+=== [#troubleshootingVsCode]#Troubleshooting# 
 
 * Reinitiating the Codewind installation
 ** If you don't click "Install" when the "Install" prompt first appears, you can access the notification again. 
@@ -56,7 +56,7 @@ For more information about troubleshooting Codewind, see the https://www.eclipse
 
 '''
 
-== Installing Codewind for Eclipse
+== [#installingCodewindEclipse]#Installing Codewind for Eclipse#
 The Codewind installation includes two steps and 1 optional step:
 
 . The Eclipse plug-in installs when you install Codewind from the Eclipse Marketplace or when you install by searching in the "Eclipse Extensions" view.
@@ -69,11 +69,11 @@ The following images are pulled. These images together form the Codewind back en
 * `eclipse/codewind-performance-amd64`
 * `eclipse/codewind-pfe-amd64`
 
-=== Using Codewind 
+=== [#usingCodewindEclipse]#Using Codewind#
 When the installation is complete, the extension is ready to use, and you are prompted to open the Codewind workspace.
 You can open the codewind-workspace or a project within the workspace as your Eclipse workspace. For more information, see https://www.eclipse.org/codewind/mdteclipsegettingstarted.html[Getting started: Codewind for Eclipse, window="_blank"]
 
-=== Working with workspaces 
+=== [#workingWorkspacesEclipse]#Working with workspaces# 
 Codewind creates the Codewind workspace on your system. The Codewind workspace is where Codewind expects to find your projects and where Codewind stores its metadata.
 
 * On macOS and Linux, the workspace folder is `~/codewind-workspace`. 
@@ -81,7 +81,7 @@ Codewind creates the Codewind workspace on your system. The Codewind workspace i
 
 When Codewind creates a new project, it is created in the Codewind workspace. If you want to add an existing project to Codewind, first copy it into the Codewind workspace.
 
-=== Updating the Codewind plug-in
+=== [#updateingCodewindEclipse]#Updating the Codewind plug-in#
 Update the Codewind Eclipse plug-in to the latest version.
 
 . From Eclipse, go to *Help > About Eclipse IDE*
@@ -94,8 +94,8 @@ Update the Codewind Eclipse plug-in to the latest version.
 . Click *OK* in the *Codewind Update* window that states that the older version of Codewind will be removed, and the newer version will be started
 . After Codewind updates, the *Codewind Explorer* view appears with your projects
 
-=== Removing containers and images 
+=== [#removingContainersEclipse]#Removing containers and images#
 To remove Codewind, see https://www.eclipse.org/codewind/mdteclipseuninstall.html[Uninstalling Codewind from Eclipse, window="_blank"].
 
-=== Troubleshooting
+=== [#troubleshootingEclipse]#Troubleshooting#
 To troubleshoot Codewind, see the https://www.eclipse.org/codewind/troubleshooting.html[Codewind Troubleshooting page, window="_blank"].

--- a/ref/general/installing-kabanero-foundation.adoc
+++ b/ref/general/installing-kabanero-foundation.adoc
@@ -1,11 +1,12 @@
-:page-layout: general-reference
+:page-layout: doc
 :page-doc-category: Installation
 :page-title: Installing Kabanero Foundation
 :linkattrs:
+:sectanchors:
 
 Today, Kabanero has been tested on the Origin Community Distribution of Kubernetes(OKD) version 3.11. There is intent to also expand testing on additional distributions including upstream Kubernetes in the future.
 
-== Prerequisites
+== [#prerequisites]#Prerequisites#
 
 * Kubernetes is installed
 * openshift_master_default_subdomain is configured
@@ -15,7 +16,7 @@ Today, Kabanero has been tested on the Origin Community Distribution of Kubernet
 * The Internal Registry is configured
 ** See more about the https://docs.okd.io/3.11/install_config/registry/index.html[Internal Registry, window="_blank"]
 
-== Installation
+== [#installation]#Installation#
 
 . In a terminal session, create and `cd` to a temporary working directory of your choice.
 
@@ -30,7 +31,7 @@ Today, Kabanero has been tested on the Origin Community Distribution of Kubernet
 * Don't forget to replace `<MY_OPENSHIFT_MASTER_DEFAULT_SUBDOMAIN>` with your subdomain, and do not include the angle brackets:
 * `openshift_master_default_subdomain=<MY_OPENSHIFT_MASTER_DEFAULT_SUBDOMAIN> ./install-kabanero-foundation.sh`
 
-== Optional sample - Appsody project with manual Tekton pipeline run
+== [#sample]#Optional sample - Appsody project with manual Tekton pipeline run#
 
 . Create a Persistent Volume for the pipeline to use. A sample hostPath `pv.yaml` is provided.
 * `oc apply -f pv.yaml`

--- a/ref/general/installing-kabanero-foundation.adoc
+++ b/ref/general/installing-kabanero-foundation.adoc
@@ -16,7 +16,7 @@ Today, Kabanero has been tested on the Origin Community Distribution of Kubernet
 * The Internal Registry is configured
 ** See more about the https://docs.okd.io/3.11/install_config/registry/index.html[Internal Registry, window="_blank"]
 
-== [#installation]#Installation#
+== [[Installation]]Installation
 
 . In a terminal session, create and `cd` to a temporary working directory of your choice.
 

--- a/ref/general/installing-kabanero-foundation.adoc
+++ b/ref/general/installing-kabanero-foundation.adoc
@@ -6,7 +6,7 @@
 
 Today, Kabanero has been tested on the Origin Community Distribution of Kubernetes(OKD) version 3.11. There is intent to also expand testing on additional distributions including upstream Kubernetes in the future.
 
-== [#prerequisites]#Prerequisites#
+== Prerequisites
 
 * Kubernetes is installed
 * openshift_master_default_subdomain is configured
@@ -16,7 +16,7 @@ Today, Kabanero has been tested on the Origin Community Distribution of Kubernet
 * The Internal Registry is configured
 ** See more about the https://docs.okd.io/3.11/install_config/registry/index.html[Internal Registry, window="_blank"]
 
-== [[Installation]]Installation
+== Installation
 
 . In a terminal session, create and `cd` to a temporary working directory of your choice.
 
@@ -31,7 +31,7 @@ Today, Kabanero has been tested on the Origin Community Distribution of Kubernet
 * Don't forget to replace `<MY_OPENSHIFT_MASTER_DEFAULT_SUBDOMAIN>` with your subdomain, and do not include the angle brackets:
 * `openshift_master_default_subdomain=<MY_OPENSHIFT_MASTER_DEFAULT_SUBDOMAIN> ./install-kabanero-foundation.sh`
 
-== [#sample]#Optional sample - Appsody project with manual Tekton pipeline run#
+== Optional sample - Appsody project with manual Tekton pipeline run
 
 . Create a Persistent Volume for the pipeline to use. A sample hostPath `pv.yaml` is provided.
 * `oc apply -f pv.yaml`

--- a/ref/general/kabenero-cli.adoc
+++ b/ref/general/kabenero-cli.adoc
@@ -1,4 +1,4 @@
-:page-layout: general-reference
+:page-layout: doc
 :page-type: doc
 :page-title: Kabanero CLI
 :page-doc-category: Getting Started
@@ -7,12 +7,12 @@
 
 Kabanero CLI is a command-line interface for managing collections and onboarding developers in a Kabanero environment. This interface is used by the enterprise, solution, or application architect who defines and manages the Kabanero collections that are used by developers to create governed applications.
 
-== Kabanero commands
+== [#kabaneroCommands]#Kabanero commands#
 
 Use the following commands to monitor and administer a Kabanero environment.
 
 
-=== Log in to Kabanero
+=== [#login]#Log in to Kabanero#
 
 Run the `kabanero login` command to authenticate to Kabanero.
 
@@ -34,7 +34,7 @@ kabanero login my.kabaneroInstance.io -u myGithubID -p myGithubPassword
 	kabanero login -u myGithubID -p myGithubPAT
 -----
 
-=== Onboard a developer
+=== [#onboardDeveloper]#Onboard a developer#
 
 Run the `kabanero onboard` command to onboard a developer to the Kabanero environment.
 
@@ -44,7 +44,7 @@ kabanero onboard github-id repo-name
 
 This command is under development. Once integrated, it sends an email to the specified user that provides the necessary information to get started with Kabanero.
 
-=== List Kabanero collections
+=== [#listCollections]#List Kabanero collections#
 
 Run the `kabanero list` command to list all the collections in a kabanero instance, along with their status.
 
@@ -52,7 +52,7 @@ Run the `kabanero list` command to list all the collections in a kabanero instan
 kabanero list
 -----
 
-=== Refresh collections
+=== [#refreshCollections]#Refresh collections#
 
 Run the `kabanero refresh` command to refresh the list of collections from master, making these collections current with the activated collections across all namespaces in the Kabanero instance. This command can also be used to restore deactivated collections. See <<Deactivate Kabanero>>.
 
@@ -60,7 +60,7 @@ Run the `kabanero refresh` command to refresh the list of collections from maste
 kabanero refresh
 ----
 
-=== Show the Kabanero version
+=== [#showKabaneroVersion]#Show the Kabanero version#
 
 Run the `kabanero version` command to display the version of kabanero that is running.
 
@@ -68,7 +68,7 @@ Run the `kabanero version` command to display the version of kabanero that is ru
 kabanero version
 ----
 
-=== Deactivate Kabanero
+=== [#deactivateKabanero]#Deactivate Kabanero#
 
 Run the `kabanero deactivate` command to prevent a collection from being shown to the development team, without deleting it.
 
@@ -80,7 +80,7 @@ Running the deactivate command removes the specified collection from the list of
 
 This command is useful when you clone a collection and customize it for your business needs. Deactivation keeps the base collection in the app hub. The base collection continues to be updated and the updates percolate up to your cloned collection. To restore a deactivated collection, run the `kabanero refresh` command. See <<Refresh collections>>.
 
-=== Log out of Kabanero
+=== [#logout]#Log out of Kabanero#
 
 Run the `kabanero logout` command to disconnect from the Kabanero instance.
 
@@ -88,9 +88,9 @@ Run the `kabanero logout` command to disconnect from the Kabanero instance.
 kabanero logout
 ----
 
-== Options
+== [#options]#Options#
 
-=== Global options
+=== [#globalOptions]#Global options#
 These options can be enabled on any Kabanero command.
 
 
@@ -104,7 +104,7 @@ These options can be enabled on any Kabanero command.
 |Turns on debug output and logging to a file in $HOME/.kabanero/logs
 |===
 
-=== Login Options
+=== [#loginOptions]#Login Options#
 Use these options with the `kabanero login` command.
 
 |===

--- a/ref/general/kabenero-cli.adoc
+++ b/ref/general/kabenero-cli.adoc
@@ -3,16 +3,17 @@
 :page-title: Kabanero CLI
 :page-doc-category: Getting Started
 :linkattrs:
+:sectanchors:
 = Kabanero CLI
 
 Kabanero CLI is a command-line interface for managing collections and onboarding developers in a Kabanero environment. This interface is used by the enterprise, solution, or application architect who defines and manages the Kabanero collections that are used by developers to create governed applications.
 
-== [#kabaneroCommands]#Kabanero commands#
+== Kabanero commands
 
 Use the following commands to monitor and administer a Kabanero environment.
 
 
-=== [#login]#Log in to Kabanero#
+=== Log in to Kabanero
 
 Run the `kabanero login` command to authenticate to Kabanero.
 
@@ -34,7 +35,7 @@ kabanero login my.kabaneroInstance.io -u myGithubID -p myGithubPassword
 	kabanero login -u myGithubID -p myGithubPAT
 -----
 
-=== [#onboardDeveloper]#Onboard a developer#
+=== Onboard a developer
 
 Run the `kabanero onboard` command to onboard a developer to the Kabanero environment.
 
@@ -44,7 +45,7 @@ kabanero onboard github-id repo-name
 
 This command is under development. Once integrated, it sends an email to the specified user that provides the necessary information to get started with Kabanero.
 
-=== [#listCollections]#List Kabanero collections#
+=== List Kabanero collections
 
 Run the `kabanero list` command to list all the collections in a kabanero instance, along with their status.
 
@@ -52,7 +53,7 @@ Run the `kabanero list` command to list all the collections in a kabanero instan
 kabanero list
 -----
 
-=== [#refreshCollections]#Refresh collections#
+=== Refresh collections
 
 Run the `kabanero refresh` command to refresh the list of collections from master, making these collections current with the activated collections across all namespaces in the Kabanero instance. This command can also be used to restore deactivated collections. See <<Deactivate Kabanero>>.
 
@@ -60,7 +61,7 @@ Run the `kabanero refresh` command to refresh the list of collections from maste
 kabanero refresh
 ----
 
-=== [#showKabaneroVersion]#Show the Kabanero version#
+=== Show the Kabanero version
 
 Run the `kabanero version` command to display the version of kabanero that is running.
 
@@ -68,7 +69,7 @@ Run the `kabanero version` command to display the version of kabanero that is ru
 kabanero version
 ----
 
-=== [#deactivateKabanero]#Deactivate Kabanero#
+=== Deactivate Kabanero
 
 Run the `kabanero deactivate` command to prevent a collection from being shown to the development team, without deleting it.
 
@@ -80,7 +81,7 @@ Running the deactivate command removes the specified collection from the list of
 
 This command is useful when you clone a collection and customize it for your business needs. Deactivation keeps the base collection in the app hub. The base collection continues to be updated and the updates percolate up to your cloned collection. To restore a deactivated collection, run the `kabanero refresh` command. See <<Refresh collections>>.
 
-=== [#logout]#Log out of Kabanero#
+=== Log out of Kabanero
 
 Run the `kabanero logout` command to disconnect from the Kabanero instance.
 
@@ -88,9 +89,9 @@ Run the `kabanero logout` command to disconnect from the Kabanero instance.
 kabanero logout
 ----
 
-== [#options]#Options#
+== Options
 
-=== [#globalOptions]#Global options#
+=== Global options
 These options can be enabled on any Kabanero command.
 
 
@@ -104,7 +105,7 @@ These options can be enabled on any Kabanero command.
 |Turns on debug output and logging to a file in $HOME/.kabanero/logs
 |===
 
-=== [#loginOptions]#Login Options#
+=== Login Options
 Use these options with the `kabanero login` command.
 
 |===

--- a/ref/general/tekton-webhooks.adoc
+++ b/ref/general/tekton-webhooks.adoc
@@ -1,31 +1,31 @@
-:page-layout: general-reference
+:page-layout: doc
 :page-doc-category: Configuration
 :page-title: Connecting Kabanero to GitHub with Tekton Webhooks
 = Connecting Kabanero to GitHub with Tekton Webhooks
 
 A webhook is an outbound HTTP request that helps you create a relationship between your GitHub repository and a particular URL, in this case a https://github.com/kabanero-io/kabanero-pipelines/tree/Readme-updates#kabanero-pipelines[Tekton pipeline, window="_blank"]. After you configure the webhook, changes you make in your GitHub repository will trigger the Tekton pipeline and its associated tasks.
 
-== Prerequisites
+== [#prerequisites]#Prerequisites#
 
 * A GitHub repository
 * https://github.com/kabanero-io/kabanero-foundation/tree/master/scripts[Kabanero Foundation, window="_blank"] or Kabanero Enterprise.
 ** Your Kabanero installation includes an instance of  the https://github.com/tektoncd/dashboard#installing-the-latest-release[Tekton Dashboard, window="_blank"] with the https://github.com/tektoncd/experimental/blob/master/webhooks-extension/docs/InstallReleaseBuild.md[Webhooks Extension, window="_blank"] installed.
 
-== Create a persistent volume
+== [#presistentVolume]#Create a persistent volume#
 Tekton pipelines need a persistent volume. If there is no network storage available, create a `hostPath pv`. For more information, see https://github.com/kabanero-io/kabanero-pipelines/tree/Readme-updates#create-a-persistent-volume[Creating a persistent volume, window="_blank"].
 
-== Generate a GitHub access token.
+== [#generateToken]#Generate a GitHub access token.#
 You need to generate a GitHub personal access token to use for creating the webhook and for accessing the repository source code during PipelineRuns. To generate the token:
 
 . Go to https://github.com/settings/tokens[github.com/settings/tokens, window="_blank"] and click `Generate new token`.
 . Check the `admin:repo_hook` option and click `Generate token`. If you are working in a private repository, additional options may be required. Check with your administrator for details. *Make sure to save the token to a file since you can't see it after you leave this page.*
 
-== Create secrets.
+== [#createSecrets]#Create secrets.#
 If you are working with a private or enterprise GitHub repository, you need to store your access token in a Kubernetes secret. From your Tekton Dashboard, select `Secrets` from the sidebar menu and click `Add Secret`. Use your GitHub user name and the personal access token you generated in the previous step to create this secret. Select the service account that is used by the pipeline you want to trigger. In this case, use `kabanero-operator`.
 
 If you want to push the image to Docker Hub, you need to create a separate secret to connect to Docker Hub. Follow the same procedure but use your Docker Hub user name and password to create this secret.
 
-== Create a webhook.
+== [#createWebhook]#Create a webhook.#
 . From your Tekton Dashboard, select `webhooks` from the sidebar menu and click `Add Webhook`.
 . Enter your information in the `Create Webhook` window.
 +
@@ -54,7 +54,7 @@ Select the Docker registry where any built images are pushed. Use the same Docke
 
 . After you complete the necessary information, click `Create`.
 
-== Confirm your webhook.
+== [#confirmWebhook]#Confirm your webhook.#
 
 . Look for the webhook in your GitHub Repository.
 * From your GitHub repository, go to the `settings` tab and select `Webhooks` from the sidebar menu. Look for the webhook you created. Sometimes the webhook initially shows a 504 error icon but after the webhook is used it changes to a green check mark.

--- a/ref/general/tekton-webhooks.adoc
+++ b/ref/general/tekton-webhooks.adoc
@@ -1,31 +1,32 @@
 :page-layout: doc
 :page-doc-category: Configuration
 :page-title: Connecting Kabanero to GitHub with Tekton Webhooks
+:sectanchors:
 = Connecting Kabanero to GitHub with Tekton Webhooks
 
 A webhook is an outbound HTTP request that helps you create a relationship between your GitHub repository and a particular URL, in this case a https://github.com/kabanero-io/kabanero-pipelines/tree/Readme-updates#kabanero-pipelines[Tekton pipeline, window="_blank"]. After you configure the webhook, changes you make in your GitHub repository will trigger the Tekton pipeline and its associated tasks.
 
-== [#prerequisites]#Prerequisites#
+== Prerequisites
 
 * A GitHub repository
 * https://github.com/kabanero-io/kabanero-foundation/tree/master/scripts[Kabanero Foundation, window="_blank"] or Kabanero Enterprise.
 ** Your Kabanero installation includes an instance of  the https://github.com/tektoncd/dashboard#installing-the-latest-release[Tekton Dashboard, window="_blank"] with the https://github.com/tektoncd/experimental/blob/master/webhooks-extension/docs/InstallReleaseBuild.md[Webhooks Extension, window="_blank"] installed.
 
-== [#presistentVolume]#Create a persistent volume#
+== Create a persistent volume
 Tekton pipelines need a persistent volume. If there is no network storage available, create a `hostPath pv`. For more information, see https://github.com/kabanero-io/kabanero-pipelines/tree/Readme-updates#create-a-persistent-volume[Creating a persistent volume, window="_blank"].
 
-== [#generateToken]#Generate a GitHub access token.#
+== Generate a GitHub access token.
 You need to generate a GitHub personal access token to use for creating the webhook and for accessing the repository source code during PipelineRuns. To generate the token:
 
 . Go to https://github.com/settings/tokens[github.com/settings/tokens, window="_blank"] and click `Generate new token`.
 . Check the `admin:repo_hook` option and click `Generate token`. If you are working in a private repository, additional options may be required. Check with your administrator for details. *Make sure to save the token to a file since you can't see it after you leave this page.*
 
-== [#createSecrets]#Create secrets.#
+== Create secrets.
 If you are working with a private or enterprise GitHub repository, you need to store your access token in a Kubernetes secret. From your Tekton Dashboard, select `Secrets` from the sidebar menu and click `Add Secret`. Use your GitHub user name and the personal access token you generated in the previous step to create this secret. Select the service account that is used by the pipeline you want to trigger. In this case, use `kabanero-operator`.
 
 If you want to push the image to Docker Hub, you need to create a separate secret to connect to Docker Hub. Follow the same procedure but use your Docker Hub user name and password to create this secret.
 
-== [#createWebhook]#Create a webhook.#
+== Create a webhook.
 . From your Tekton Dashboard, select `webhooks` from the sidebar menu and click `Add Webhook`.
 . Enter your information in the `Create Webhook` window.
 +
@@ -54,7 +55,7 @@ Select the Docker registry where any built images are pushed. Use the same Docke
 
 . After you complete the necessary information, click `Create`.
 
-== [#confirmWebhook]#Confirm your webhook.#
+== Confirm your webhook.
 
 . Look for the webhook in your GitHub Repository.
 * From your GitHub repository, go to the `settings` tab and select `Webhooks` from the sidebar menu. Look for the webhook you created. Sometimes the webhook initially shows a 504 error icon but after the webhook is used it changes to a green check mark.


### PR DESCRIPTION
Doc changes to support the updated docs on the website (https://github.com/kabanero-io/kabanero-website/pull/201/files).  The layout for the docs is named `doc` and docs that want to implement clickable anchors should include `:sectanchors:`