### PR TITLE
add how to view landing page in install doc

### DIFF
--- a/ref/general/installing-kabanero-foundation.adoc
+++ b/ref/general/installing-kabanero-foundation.adoc
@@ -33,6 +33,28 @@ Today, Kabanero has been tested on the Origin Community Distribution of Kubernet
 * Don't forget to replace `<MY_OPENSHIFT_MASTER_DEFAULT_SUBDOMAIN>` with your subdomain, and do not include the angle brackets:
 * `openshift_master_default_subdomain=<MY_OPENSHIFT_MASTER_DEFAULT_SUBDOMAIN> ./install-kabanero-foundation.sh`
 
+== After Install
+
+The **Kabanero Landing Page** is installed as part of the install process and is a good next step to go explore information about your Kabanero instance.
+
+=== View the Landing Page
+. In your OKD Console
+.. Click on the **Kabanero** tab on the left hand navigation.
+
+**Note**: If you do not see the **Kabanero** tab, proper certificates might not be installed in your cluster. You will have to accept the self-signed certificate before the **Kabanero** tab is displayed.
+To accept the self signed certificate you will have to **go to the landing page URL in your browser and accept the self-signed certificate**. 
+
+There are two ways to get the landing page URL::
+
+Using the `oc` CLI:::
+. Open a terminal and run: `oc get routes -n kabanero`
+. Find the result with the name `kabanero-landing`. The URL is displayed under **HOST/PORT** for that row.
+
+Using the OKD Console:::
+. Switch the project to **kabanero**
+. Under **Applications** click **Routes**
+. The landing page name is **kabanero-landing** which should be in the list of routes. Click the URL under **Hostname** to open the landing application
+
 == Optional sample - Appsody project with manual Tekton pipeline run
 
 . Create a Persistent Volume for the pipeline to use. A sample hostPath `pv.yaml` is provided.
@@ -49,4 +71,3 @@ Today, Kabanero has been tested on the Origin Community Distribution of Kubernet
 
 . Optional - Make detailed pipeline changes by accessing the Tekton dashboard
 * `http://tekton-dashboard.<MY_OPENSHIFT_MASTER_DEFAULT_SUBDOMAIN>`
-

--- a/ref/general/whats-new.md
+++ b/ref/general/whats-new.md
@@ -1,6 +1,4 @@
 ---
-layout: general-reference
-type: general
 version: v0.0.3
 title: What's New In Kabanero v0.0.3
 ---


### PR DESCRIPTION
closes kabanero-io/kabanero-landing/issues/30

also update what's new meta data (it was outdated)

rendered doc looks like

![image](https://user-images.githubusercontent.com/3623618/66582173-530fd100-eb4f-11e9-9ea2-d7a938024d3c.png)
