### PR TITLE
Code review comments - use `oc edit` instead of get/edit/apply.

### DIFF
--- a/ref/general/collection-install.adoc
+++ b/ref/general/collection-install.adoc
@@ -14,7 +14,7 @@ A Kabanero custom resource (CR) instance can be configured to use an alternate c
 * Replace `<organization>` with your Github organization name
 * Replace `<release>` with the name of the release that was created
 
-. Obtain a copy of your current Kabanero CR instance.  Use `oc get kabaneros -n kabanero` to obtain a list of all Kabanero CR instances in namespace `kabanero`.  The default name for the CR instance is `kabanero`.  Then, obtain the speific CR instance using `oc get kabanero <name> -o yaml > kabanero.yaml`, replacing `<name>` with the instance name, to save a copy to the current directory.
+. Find the name of your Kabanero CR instance.  Use `oc get kabaneros -n kabanero` to obtain a list of all Kabanero CR instances in namespace `kabanero`.  The default name for the CR instance is `kabanero`.  Then, edit the speific CR instance using `oc edit kabanero <name> -n kabanero`, replacing `<name>` with the instance name.
 
 . Modify your Kabanero custom resource (CR) instance to target the new collections that were pushed to the remote Github repository, and the teams in Github that should administer the collection(s).  Specifically:
 * The `Spec.Collections.Repositories.url` attribute should be set to the URL of the collection repository.
@@ -43,8 +43,8 @@ spec:
 ```
 +
 For more information about other fields that can be customized in the Kabanero CR instance, see link:kabanero-cr-config.html[the Kabanero CR configuration reference].
-
-. Apply your changes to the Kabanero CR instance.  For example, in the Kabanero namespace, use `oc apply -f kabanero.yaml -n kabanero`.
++
+When you are done editing, save your changes and exit the editor.  The updated Kabanero CR instance will be applied to your cluster.
 
 . The Kabanero operator will now load the collections in the repository.  To see a list of all collections in the `kabanero` namespace, use `oc get collections -n kabanero`.  If the kabanero-operator is unable to apply the collections, the `Status` section of the Kabanero CR instance or the Collection CR instances will contain more information.
 


### PR DESCRIPTION
@davco01a suggested that we have the user use `oc edit` as opposed to a get/edit/apply model when editing the Kabanero CR instance.