### PR TITLE
Remove duplicate header

### DIFF
--- a/ref/general/kabanero-env-vars.md
+++ b/ref/general/kabanero-env-vars.md
@@ -3,7 +3,6 @@ layout: doc
 doc-category: Reference
 title: Environment variables
 ---
-# Environment variables
 
 Kabanero Collections are built with a default set of configuration options that you can modify by setting environment variables.
 


### PR DESCRIPTION
Duplicate header in Docs caused by a #1 and the title: frontmatter.
Removed #1

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>