### PR TITLE
Modify topics to remove specific Kabanero version numbers

### DIFF
--- a/ref/general/installing-kabanero-foundation.adoc
+++ b/ref/general/installing-kabanero-foundation.adoc
@@ -20,17 +20,23 @@ Kabanero uses Operator Lifecycle Manager (OLM) to manage its prerequisites.  Sev
 
 === Scripted installation
 
-. Obtain the installation script for the release of Kabanero that you wish to install.
-* `curl -s -O -L https://github.com/kabanero-io/kabanero-operator/releases/download/0.3.1/install.sh`
-
+. Obtain the installation script for the release of Kabanero that you want to install by running the following command:
++
+----
+curl -s -O -L https://github.com/kabanero-io/kabanero-operator/releases/download/<version>/install.sh
+----
+Where `<version>` is the 3-digit Kabanero version number. To find the latest release, go to the link:https://github.com/kabanero-io/kabanero-operator/releases[release page] and look
+for the *Latest release* label.
 . Review the `install.sh` script for any optional components that can be enabled by setting the required environment variable, or by editing the value in the script directly.  Optional components are listed at the top of the script, below the section titled `Optional components`.
 
-. As a `cluster-admin`, run the script:
-.. Ensure you are logged into your cluster with the https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands[`oc login` command]
-.. If installing the optional kAppNav component, specify `yes` on the ENABLE_KAPPNAV environment variable.  If not, specify `no`.
-.. `ENABLE_KAPPNAV=yes|no ./install.sh`
+. Follow these steps to run the script:
 
-. As a `cluster-admin`, or as a user with `create` and `update` authority to the `kabaneros.kabanero.io` kind, create a `Kabanero` custom resource (CR) instance.  A sample `oc apply` command which applies the default instance for this release of Kabanero, including the default collections, is shown when the `install.sh` script finishes running.  You can modify the CR instance to include the URL of a custom collection and the GitHub information necessary to administer that collection.  For more information on customizing the CR instance, see link:kabanero-cr-config.html[the Kabanero CR configuration reference].
+.. Ensure that you are logged in to your cluster with the https://docs.openshift.com/container-platform/4.2/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands[`oc login` command]
+.. Ensure that you are a user with `cluster-admin` privileges.
+.. Decide whether you want to install the optional kAppNav component, which requires the `ENABLE_KAPPNAV=yes|no` environment variable.
+.. Run the following command, substituting `<option>` with `yes` or `no` to install kAppNav: `ENABLE_KAPPNAV=<option> ./install.sh`
+
+. As a user with `cluster-admin` privileges, or as a user with `create` and `update` authority to the `kabaneros.kabanero.io` kind, create a `Kabanero` custom resource (CR) instance.  A sample `oc apply` command which applies the default instance for this release of Kabanero, including the default collections, is shown when the `install.sh` script finishes running.  You can modify the CR instance to include the URL of a custom collection and the GitHub information necessary to administer that collection.  For more information on customizing the CR instance, see link:kabanero-cr-config.html[the Kabanero CR configuration reference].
 
 === Manual installation
 
@@ -42,7 +48,7 @@ Kabanero uses Operator Lifecycle Manager (OLM) to manage its prerequisites.  Sev
 
 . Install the Appsody operator using the instructions to link:https://docs.openshift.com/container-platform/4.2/operators/olm-adding-operators-to-cluster.html[add an operator to your cluster].  Select the `certified-operators` catalog and the `beta` channel.  This operator should be installed at the cluster scope.
 
-. Install the OLM CatalogSource containing the Kabanero operator.  The following YAML can be used, after substituting the required version (the example uses version 0.3.1):
+. Install the OLM CatalogSource containing the Kabanero operator.  Use the following YAML file, substituting `<version>` with the 3-digit Kabanero version number required:
 +
 [source,yaml]
 ----
@@ -53,41 +59,40 @@ metadata:
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: kabanero/kabanero-operator-registry:0.3.1
+  image: kabanero/kabanero-operator-registry:<version>
 ----
 
 . Create the `kabanero` namespace using `oc new-project kabanero`
 
 . Install the Che operator using the instructions to link:https://docs.openshift.com/container-platform/4.2/operators/olm-adding-operators-to-cluster.html[add an operator to your cluster].  Select the `community-operators` catalog and the `stable` channel.  This operator should be installed to the `kabanero` namespace.
 
-. Install the Kabanero operator using the instructions to link:https://docs.openshift.com/container-platform/4.2/operators/olm-adding-operators-to-cluster.html[add an operator to your cluster].  Select the `kabanero-catalog` catalog and the `release-0.3` channel.  This operator should be installed to the `kabanero` namespace.
+. Install the Kabanero operator using the instructions to link:https://docs.openshift.com/container-platform/4.2/operators/olm-adding-operators-to-cluster.html[add an operator to your cluster].  Select the `kabanero-catalog` catalog and the `release-<version>` channel, where `<version>` is the first 2 digits of the Kabanero version you are installing.  This operator should be installed to the `kabanero` namespace.
 
-. As a `cluster-admin`, or as a user with `create` and `update` authority to the `kabaneros.kabanero.io` kind, create a `Kabanero` custom resource (CR) instance.  A sample `oc apply` command which applies the default instance for this release of Kabanero, including the default collections, is shown when the `install.sh` script finishes running.  You can modify the CR instance to include the URL of a custom collection and the GitHub information necessary to administer that collection.  For more information on customizing the CR instance, see link:kabanero-cr-config.html[the Kabanero CR configuration reference].
+. As a user with `cluster-admin` privileges, or as a user with `create` and `update` authority to the `kabaneros.kabanero.io` kind, create a `Kabanero` custom resource (CR) instance.  A sample `oc apply` command which applies the default instance for this release of Kabanero, including the default collections, is shown when the `install.sh` script finishes running.  You can modify the CR instance to include the URL of a custom collection and the GitHub information necessary to administer that collection.  For more information on customizing the CR instance, see link:kabanero-cr-config.html[the Kabanero CR configuration reference].
 
-== After installing
+After the installation completes, view the **Kabanero Landing Page** to explore information about your Kabanero instance.
 
-The **Kabanero Landing Page** is installed as part of the install process and is a good next step to go explore information about your Kabanero instance.
-
-=== View the landing page
+=== Viewing the landing page
 . In your OpenShift Console
 .. Click on the **Kabanero** tab on the left hand navigation.
 
-**Note**: If you do not see the **Kabanero** tab, proper certificates might not be installed in your cluster. You will have to accept the self-signed certificate before the **Kabanero** tab is displayed.
-To accept the self-signed certificate, **go to the landing page URL in your browser and accept the self-signed certificate**.
+**Note**: If you do not see the **Kabanero** tab, the correct certificates might not be installed in your cluster. To display the **Kabanero** tab, you must navigate to the
+landing page URL in your browser and accept the self-signed certificate.
 
-There are two ways to get the landing page URL::
+Use one of the following methods to find the landing page URL:
 
-Using the `oc` CLI:::
+Use the `oc` CLI:::
 . Open a terminal and run: `oc get routes -n kabanero`
 . Find the result with the name `kabanero-landing`. The URL is displayed under **HOST/PORT** for that row.
 
-Using the OpenShift Console:::
+Use the OpenShift Console:::
 . Switch the project to **kabanero**
 . Under **Applications** click **Routes**
 . The landing page name is **kabanero-landing**, which should be in the list of routes; click the URL under **Hostname** to open the landing application
 
 === If the landing page is not responding
-It might take some time for the landing page and other pods to be created and started. You can check the status of the Kabanero pods with `oc get pods -n kabanero`. Wait until they all have a status of *Running*.
+It might take some time for the landing page and other pods to be created and started. You can check the status of the Kabanero pods with the command `oc get pods -n kabanero`.
+The landing page responds when the *STATUS* of all Kabanero pods is *Running*.
 ----
 NAME                                  READY     STATUS    RESTARTS   AGE
 ...

--- a/ref/general/uninstalling-kabanero-foundation.adoc
+++ b/ref/general/uninstalling-kabanero-foundation.adoc
@@ -4,18 +4,22 @@
 :linkattrs:
 :sectanchors:
 
-== Uninstalling Kabanero Foundation
 
-A sample uninstall script is available in the kabanero-operator Github repository.  This script will perform the reverse of the `install.sh` script. Before running the `uninstall.sh` script, consider removing any resources that were not created by the 'install-kabanero-foundation' script, such as webhooks, Knative services or Appsody applications.
+A sample script to uninstall Kabanero Foundation is available in the *kabanero-operator* GitHub repository. Before running the `uninstall.sh` script,
+consider removing any resources that were not created by the `install.sh` script, such as webhooks, Knative services, or Appsody applications.
 
-The sample uninstallation script will completely remove all dependencies from the cluster, including Knative, Tekton and OpenShift Service Mesh.  You can modify your local copy of the script if desired.
+The sample script completely removes all dependencies from the cluster, including Knative, Tekton, and OpenShift Service Mesh.
+If you want to keep some of these dependencies, modify your local copy.
 
-== Uninstallation
+Follow these steps:
 
-. Obtain the uninstallation script for the release of Kabanero that you wish to install.
-* `curl -s -O -L https://github.com/kabanero-io/kabanero-operator/releases/download/0.3.1/uninstall.sh`
-
-. As a `cluster-admin`, execute the sample uninstallation script:
+. Obtain the `uninstall.sh` script for the release of Kabanero that you want to uninstall by running the following command:
++
+----
+curl -s -O -L https://github.com/kabanero-io/kabanero-operator/releases/download/<version>/uninstall.sh
+----
+Where `<version>` is the 3-digit Kabanero version number.
+. As a user with `cluster-admin` privileges, run the script:
 +
 ----
 ./uninstall.sh


### PR DESCRIPTION
To avoid updating the topics for every releae, modify the instructions
to refer to `<version>` and provide users with a way of finding out
what the latest version is.

Work determined from https://github.com/kabanero-io/docs/issues/212

Signed-off-by: Sue Chaplain <sue_chaplain@uk.ibm.com>