### PR TITLE
multiple namespace instructions updates kabanero 0.3.x

### DIFF
--- a/ref/general/configuration/app-deploy-namespace.adoc
+++ b/ref/general/configuration/app-deploy-namespace.adoc
@@ -55,7 +55,7 @@ oc get smmr default -n istio-system -o yaml > smmr.yaml
 ----
 +
 
-Edit the `smmr.yaml` file and specify the namespaces where you intend to deploy applications as separate entries in list for the `members` attribute.  Specify multiple namespaces as a list.
+Edit the `smmr.yaml` file and specify the namespaces where you intend to deploy applications as separate entries in the list for the `members` attribute.
 The following section of a `smmr.yaml` file shows the `production` and `test` namespaces in the `members` list, after the existing namespaces:
 +
 ----

--- a/ref/general/configuration/app-deploy-namespace.adoc
+++ b/ref/general/configuration/app-deploy-namespace.adoc
@@ -55,8 +55,8 @@ oc get smmr default -n istio-system -o yaml > smmr.yaml
 ----
 +
 
-Edit `smmr.yaml` and specify the namespaces where you intend to deploy applications, by updating the `members` attribute.  Specify multiple namespaces as a list.
-The following section of a `smmr.yaml` file shows the `production` and `test` namespaces in the members list, after the existing namespaces:
+Edit the `smmr.yaml` file and specify the namespaces where you intend to deploy applications as separate entries in list for the `members` attribute.  Specify multiple namespaces as a list.
+The following section of a `smmr.yaml` file shows the `production` and `test` namespaces in the `members` list, after the existing namespaces:
 +
 ----
 apiVersion: maistra.io/v1

--- a/ref/general/configuration/app-deploy-namespace.adoc
+++ b/ref/general/configuration/app-deploy-namespace.adoc
@@ -47,6 +47,40 @@ For a full list of supported attributes in a `kabanero.yaml` configuration file,
 oc apply -f kabanero.yaml -n kabanero
 ----
 +
+
+. If your application's `app-deploy.yaml` sets `spec.createKnativeService` to `true`, you will need to modify the Service Mesh Member Role to include the deployment namespaces.  Obtain a copy of the Service Mesh Member Role (SMMR) by running the following command:
++
+----
+oc get smmr default -n istio-system -o yaml > smmr.yaml
+----
++
+
+Edit `smmr.yaml` and specify the namespaces where you intend to deploy applications, by updating the `members` attribute.  Specify multiple namespaces as a list.
+The following section of a `smmr.yaml` file shows the `production` and `test` namespaces in the members list, after the existing namespaces:
++
+----
+apiVersion: maistra.io/v1
+kind: ServiceMeshMemberRole
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  members:
+  - knative-serving
+  - tekton-pipelines
+  - kabanero
+  - production
+  - test
+----
++
+
+Apply your changes to the Service Mesh Member Role by running the following command:
++
+----
+oc apply -f smmr.yaml -n istio-system
+----
++
+
 . Modify your Appsody application `app-deploy.yaml` file to use one of the namespaces you configured in the `targetNamespaces` attribute of the Kabanero CR instance.
 Here is an example `app-deploy.yaml` file that deploys the `appsody-hello-world` application to the `test` namespace:
 +


### PR DESCRIPTION
The OpenShift Serverless operator v1.1.0 requires applications to explicitly manage the service mesh member role (smmr).  If applications use Knative, they will need to perform this step.  Kabanero versions 0.3 and 0.4 use the Serverless operator v1.1.0.  This PR is for 0.3.  A separate PR will handle 0.4.