### PR TITLE
CodeReady install docs

### DIFF
--- a/ref/general/configuration/kabanero-cr-config.adoc
+++ b/ref/general/configuration/kabanero-cr-config.adoc
@@ -89,7 +89,7 @@ specify the following fields:
 *** `enable` - Controls whether the Kabanero landing page is deployed by
     the Kabanero operator.  Valid values are `true` and `false`.  The default
     value is `true`.
-** `codereadyWorkspaces`
+** `codeReadyWorkspaces`
 *** `enable` - Controls whether Kabanero will deploy an instance of 
     CodeReady Workspaces.  Valid values are `true` and `false`.
     The default value is `false`.

--- a/ref/general/installation/installing-codeready-and-codewind.adoc
+++ b/ref/general/installation/installing-codeready-and-codewind.adoc
@@ -1,0 +1,68 @@
+:page-layout: doc
+:page-doc-category: Installation
+:page-title: Installing Codewind in CodeReady Workspaces
+:linkattrs:
+:page-doc-number: 3.0
+:sectanchors:
+Eclipse Codewind enables you to develop microservice applications from application stacks in an IDE. Follow one of these
+links for your chosen IDE:
+
+== Prerequisites
+
+CodeReady Workspaces requires at least one 1Gi RWO (ReadWriteOnce) persistent volume on the cluster to install, and additional 1Gi RWO volumes for each workspace that users create.
+
+Each Codewind workspace requires at least one 1Gi RWX (ReadWriteMany) persistent volume as well.
+
+== Installing CodeReady Workspaces
+To install CodeReady workspaces, set `Spec.codereadyWorkspaces.enable: true` in the Kabanero CR instance and apply it.
+
+A sample Kabanero CR instance might look like:
+```yaml
+apiVersion: kabanero.io/v1alpha2
+kind: Kabanero
+metadata:
+  name: kabanero
+  namespace: kabanero
+spec:
+  stacks:
+    repositories:
+    - name: custom
+      https:
+        url: https://github.example.com/my_org/stacks/releases/download/0.6.0/incubator-index.yaml
+  codereadyWorkspaces
+    enable: true
+```
+
+=== Configuring CodeReady Workspaces
+The Kabanero CR instance provides additional fields allowing you to configure your install of CodeReady Workspaces. 
+
+* Set `Spec.codereadyWorkspaces.operator.instance.tlsSupport` to `true` if you wish to install CodeReady Workspaces with TLS Support. 
+  *Note:* If your cluster is set up with self-signed certificates, `Spec.codereadyWorkspaces.operator.instance.selfSignedCert` must also be set to `true`
+* Set `Spec.codereadyWorkspaces.operator.instance.openShiftOAuth` to `true` if you wish to use your OpenShift accounts with CodeReady Workspaces.  Requires permanent users (accounts other than kube:admin) set up first.
+
+Consult link:kabanero-cr-config.html[Configuring a Kabanero CR Instance] for the full list of configurable fields
+
+
+== Installing Codewind
+Ensure CodeReady Workspaces is installed on your OpenShift cluster.
+
+. Log in to CodeReady Workspaces with your desired account.
+. Click `Create Workspace`
+. Under `Name`, give your workspace some meaningful name
+. Under `Select Stack`, select `Codewind`
+. Click `Create & Open` to create and start Codewind in CodeReady Workspaces
+
+CodeReady Workspaces will proceed to bring up Codewind, and install the Codewind plugins. This process may take a couple of minutes for all of the necessary components to get pulled and started.
+
+Consult the https://www.eclipse.org/codewind/mdt-che-overview.html[Codewind on Che documentation, window="_blank"] for additional information and next steps.
+
+=== Stopping or Uninstalling Codewind
+If at any point, you wish to stop the Codewind workspace, you can do the following:
+
+. Login to your CodeReady Workspaces account and access the dashboard.
+. Click on `Workspaces` in the sidebar
+. To pause the Codewind workspace: Select the Codewind workspace and under `Actions` press the `Stop workspace` button.
+. To delete the Codewind workspace: Select the Codewind workspace and press the `Delete` button.
+
+=== Troubleshooting
+To troubleshoot Codewind, see the https://www.eclipse.org/codewind/troubleshooting.html[Codewind Troubleshooting page, window="_blank"].

--- a/ref/general/installation/installing-codeready-and-codewind.adoc
+++ b/ref/general/installation/installing-codeready-and-codewind.adoc
@@ -56,7 +56,7 @@ If CodeReady Workspaces is set up to use the self-signed certificates provided b
 . Go to Settings -> Privacy and Security -> Manage certificates.
 . Import the certificate into your system and set its trust to `Always trust`.
 
-*Firefox:*
+*Firefox (version 71 or newer):*
 
 . Access the CodeReady Workspaces route in your browser.
 . View the route's certificate in your browser.

--- a/ref/general/installation/installing-codeready-and-codewind.adoc
+++ b/ref/general/installation/installing-codeready-and-codewind.adoc
@@ -22,26 +22,47 @@ apiVersion: kabanero.io/v1alpha2
 kind: Kabanero
 metadata:
   name: kabanero
-  namespace: kabanero
 spec:
-  stacks:
-    repositories:
-    - name: custom
-      https:
-        url: https://github.example.com/my_org/stacks/releases/download/0.6.0/incubator-index.yaml
-  codeReadyWorkspaces
+  version: "0.6.0"
+  codeReadyWorkspaces:
     enable: true
+    operator:
+      customResourceInstance:
+        tlsSupport: true
+        selfSignedCert: true
+  stacks: 
+    repositories: 
+    - name: central
+      https:
+        url: https://github.com/kabanero-io/collections/releases/download/0.6.0/kabanero-index.yaml
 ```
 
 === Configuring CodeReady Workspaces
 The Kabanero CR instance provides additional fields allowing you to configure your install of CodeReady Workspaces. 
 
-* Set `Spec.codeReadyWorkspaces.operator.instance.tlsSupport` to `true` if you wish to install CodeReady Workspaces with TLS Support. 
-  *Note:* If your cluster is set up with self-signed certificates, `Spec.codeReadyWorkspaces.operator.instance.selfSignedCert` must also be set to `true`
-* Set `Spec.codeReadyWorkspaces.operator.instance.openShiftOAuth` to `true` if you wish to use your OpenShift accounts with CodeReady Workspaces.  Requires permanent users (accounts other than kube:admin) set up first.
+* Set `Spec.codeReadyWorkspaces.operator.customResourceInstance.tlsSupport` to `true` if you wish to install CodeReady Workspaces with TLS Support. 
+  *Note:* If your OpenShift cluster's router is set up with self-signed certificates, `Spec.codeReadyWorkspaces.operator.instance.selfSignedCert` must also be set to `true`. 
+* Set `Spec.codeReadyWorkspaces.operator.customResourceInstance.openShiftOAuth` to `true` if you wish to use your OpenShift accounts with CodeReady Workspaces.  Requires permanent users (accounts other than kube:admin) set up first.
 
 Consult link:kabanero-cr-config.html[Configuring a Kabanero CR Instance] for the full list of configurable fields
 
+=== Using CodeReady Workspaces with Self-Signed certificates
+If CodeReady Workspaces is set up to use the self-signed certificates provided by the OpenShift cluster's router, then you must do the following:
+
+*Google Chrome:*
+
+. Access the CodeReady Workspaces route in your browser
+. Download the route's certificate to your system
+. Go to Settings -> Privacy and Security -> Manage certificates
+. Import the certificate into your system and set its trust to `Always trust`
+
+*Firefox:*
+
+. Access the CodeReady Workspaces route in your browser
+. View the route's certificate in your browser
+. Download the certificate titled `ingress-operator`
+. Go to Preferences -> Privacy and Security -> View certificates
+. Import the `ingress-operator` certificate as an authority into Firefox.
 
 == Installing Codewind
 Ensure CodeReady Workspaces is installed on your OpenShift cluster.

--- a/ref/general/installation/installing-codeready-and-codewind.adoc
+++ b/ref/general/installation/installing-codeready-and-codewind.adoc
@@ -9,12 +9,12 @@ links for your chosen IDE:
 
 == Prerequisites
 
-CodeReady Workspaces requires at least one 1Gi RWO (ReadWriteOnce) persistent volume on the cluster to install, and additional 1Gi RWO volumes for each workspace that users create.
+CodeReady Workspaces requires at least two 1Gi ReadWriteOnce (RWO) persistent volumes on the cluster to install and a 1Gi RWO volume for each created workspace.
 
-Each Codewind workspace requires at least one 1Gi RWX (ReadWriteMany) persistent volume as well.
+Each Codewind Workspace also requires at least on 1Gi ReadWriteMany (RWX) persistent volume.
 
 == Installing CodeReady Workspaces
-To install CodeReady workspaces, set `Spec.codeReadyWorkspaces.enable: true` in the Kabanero CR instance and apply it.
+To install CodeReady Workspaces, set `Spec.codeReadyWorkspaces.enable: true` in the Kabanero custom resource (CR) instance and apply it.
 
 A sample Kabanero CR instance might look like:
 ```yaml
@@ -51,39 +51,39 @@ If CodeReady Workspaces is set up to use the self-signed certificates provided b
 
 *Google Chrome:*
 
-. Access the CodeReady Workspaces route in your browser
-. Download the route's certificate to your system
-. Go to Settings -> Privacy and Security -> Manage certificates
-. Import the certificate into your system and set its trust to `Always trust`
+. Access the CodeReady Workspaces route in your browser.
+. Download the route's certificate to your system.
+. Go to Settings -> Privacy and Security -> Manage certificates.
+. Import the certificate into your system and set its trust to `Always trust`.
 
 *Firefox:*
 
-. Access the CodeReady Workspaces route in your browser
-. View the route's certificate in your browser
-. Download the certificate titled `ingress-operator`
-. Go to Preferences -> Privacy and Security -> View certificates
+. Access the CodeReady Workspaces route in your browser.
+. View the route's certificate in your browser.
+. Download the certificate titled `ingress-operator`.
+. Go to Preferences -> Privacy and Security -> View certificates.
 . Import the `ingress-operator` certificate as an authority into Firefox.
 
 == Installing Codewind
 Ensure CodeReady Workspaces is installed on your OpenShift cluster.
 
 . Log in to CodeReady Workspaces with your desired account.
-. Click `Create Workspace`
-. Under `Name`, give your workspace some meaningful name
-. Under `Select Stack`, select `Codewind`
-. Click `Create & Open` to create and start Codewind in CodeReady Workspaces
+. Click `Create Workspace`.
+. Under `Name`, give your workspace some meaningful name.
+. Under `Select Stack`, select `Codewind`.
+. Click `Create & Open` to create and start Codewind in CodeReady Workspaces.
 
 CodeReady Workspaces will proceed to bring up Codewind, and install the Codewind plugins. This process may take a couple of minutes for all of the necessary components to get pulled and started.
 
 Consult the https://www.eclipse.org/codewind/mdt-che-overview.html[Codewind on Che documentation, window="_blank"] for additional information and next steps.
 
 === Stopping or Uninstalling Codewind
-If at any point, you wish to stop the Codewind workspace, you can do the following:
+If at any point, you need to stop the Codewind Workspace, you can:
 
-. Login to your CodeReady Workspaces account and access the dashboard.
-. Click on `Workspaces` in the sidebar
-. To pause the Codewind workspace: Select the Codewind workspace and under `Actions` press the `Stop workspace` button.
-. To delete the Codewind workspace: Select the Codewind workspace and press the `Delete` button.
+. Log in to your CodeReady Workspaces account and access the dashboard.
+. Click on `Workspaces` in the sidebar.
+. To pause the Codewind Workspace: Select the Codewind Workspace and under `Actions` click the `Stop workspace` button.
+. To delete the Codewind Workspace: Select the Codewind Workspace and click the `Delete` button.
 
 === Troubleshooting
 To troubleshoot Codewind, see the https://www.eclipse.org/codewind/troubleshooting.html[Codewind Troubleshooting page, window="_blank"].

--- a/ref/general/installation/installing-codeready-and-codewind.adoc
+++ b/ref/general/installation/installing-codeready-and-codewind.adoc
@@ -14,7 +14,7 @@ CodeReady Workspaces requires at least one 1Gi RWO (ReadWriteOnce) persistent vo
 Each Codewind workspace requires at least one 1Gi RWX (ReadWriteMany) persistent volume as well.
 
 == Installing CodeReady Workspaces
-To install CodeReady workspaces, set `Spec.codereadyWorkspaces.enable: true` in the Kabanero CR instance and apply it.
+To install CodeReady workspaces, set `Spec.codeReadyWorkspaces.enable: true` in the Kabanero CR instance and apply it.
 
 A sample Kabanero CR instance might look like:
 ```yaml
@@ -29,16 +29,16 @@ spec:
     - name: custom
       https:
         url: https://github.example.com/my_org/stacks/releases/download/0.6.0/incubator-index.yaml
-  codereadyWorkspaces
+  codeReadyWorkspaces
     enable: true
 ```
 
 === Configuring CodeReady Workspaces
 The Kabanero CR instance provides additional fields allowing you to configure your install of CodeReady Workspaces. 
 
-* Set `Spec.codereadyWorkspaces.operator.instance.tlsSupport` to `true` if you wish to install CodeReady Workspaces with TLS Support. 
-  *Note:* If your cluster is set up with self-signed certificates, `Spec.codereadyWorkspaces.operator.instance.selfSignedCert` must also be set to `true`
-* Set `Spec.codereadyWorkspaces.operator.instance.openShiftOAuth` to `true` if you wish to use your OpenShift accounts with CodeReady Workspaces.  Requires permanent users (accounts other than kube:admin) set up first.
+* Set `Spec.codeReadyWorkspaces.operator.instance.tlsSupport` to `true` if you wish to install CodeReady Workspaces with TLS Support. 
+  *Note:* If your cluster is set up with self-signed certificates, `Spec.codeReadyWorkspaces.operator.instance.selfSignedCert` must also be set to `true`
+* Set `Spec.codeReadyWorkspaces.operator.instance.openShiftOAuth` to `true` if you wish to use your OpenShift accounts with CodeReady Workspaces.  Requires permanent users (accounts other than kube:admin) set up first.
 
 Consult link:kabanero-cr-config.html[Configuring a Kabanero CR Instance] for the full list of configurable fields
 

--- a/ref/general/installation/installing-codeready-and-codewind.adoc
+++ b/ref/general/installation/installing-codeready-and-codewind.adoc
@@ -14,7 +14,7 @@ CodeReady Workspaces requires at least two 1Gi ReadWriteOnce (RWO) persistent vo
 Each Codewind workspace also requires at least on 1Gi ReadWriteMany (RWX) persistent volume.
 
 == Installing CodeReady Workspaces
-To install CodeReady Workspaces, set `Spec.codeReadyWorkspaces.enable: true` in the Kabanero custom resource (CR) instance and apply it.
+To install CodeReady Workspaces, set `Spec.codeReadyWorkspaces.enable: true` in the Kabanero custom resource (Kabanero CR) instance and apply it.
 
 A sample Kabanero CR instance might look like:
 ```yaml
@@ -73,7 +73,7 @@ Ensure CodeReady Workspaces is installed on your OpenShift cluster.
 . Under `Select Stack`, select `Codewind`.
 . Click `Create & Open` to create and start Codewind in CodeReady Workspaces.
 
-CodeReady Workspaces will proceed to bring up Codewind, and install the Codewind plugins. This process may take a couple of minutes for all of the necessary components to get pulled and started.
+CodeReady Workspaces then proceeds to bring up Codewind, and install the Codewind plugins. This process may take a couple of minutes for all of the necessary components to get pulled and started.
 
 Consult the https://www.eclipse.org/codewind/mdt-che-overview.html[Codewind on Che documentation, window="_blank"] for additional information and next steps.
 

--- a/ref/general/installation/installing-codeready-and-codewind.adoc
+++ b/ref/general/installation/installing-codeready-and-codewind.adoc
@@ -11,7 +11,7 @@ links for your chosen IDE:
 
 CodeReady Workspaces requires at least two 1Gi ReadWriteOnce (RWO) persistent volumes on the cluster to install and a 1Gi RWO volume for each created workspace.
 
-Each Codewind Workspace also requires at least on 1Gi ReadWriteMany (RWX) persistent volume.
+Each Codewind workspace also requires at least on 1Gi ReadWriteMany (RWX) persistent volume.
 
 == Installing CodeReady Workspaces
 To install CodeReady Workspaces, set `Spec.codeReadyWorkspaces.enable: true` in the Kabanero custom resource (CR) instance and apply it.
@@ -78,12 +78,12 @@ CodeReady Workspaces will proceed to bring up Codewind, and install the Codewind
 Consult the https://www.eclipse.org/codewind/mdt-che-overview.html[Codewind on Che documentation, window="_blank"] for additional information and next steps.
 
 === Stopping or Uninstalling Codewind
-If at any point, you need to stop the Codewind Workspace, you can:
+If at any point, you need to stop the Codewind workspace, you can:
 
-. Log in to your CodeReady Workspaces account and access the dashboard.
+. Log in to your CodeReady workspaces account and access the dashboard.
 . Click on `Workspaces` in the sidebar.
-. To pause the Codewind Workspace: Select the Codewind Workspace and under `Actions` click the `Stop workspace` button.
-. To delete the Codewind Workspace: Select the Codewind Workspace and click the `Delete` button.
+. To pause the Codewind workspace: Select the Codewind workspace and under `Actions` click the `Stop workspace` button.
+. To delete the Codewind workspace: Select the Codewind workspace and click the `Delete` button.
 
 === Troubleshooting
 To troubleshoot Codewind, see the https://www.eclipse.org/codewind/troubleshooting.html[Codewind Troubleshooting page, window="_blank"].


### PR DESCRIPTION
First crack at the install documentation for CodeReady Workspaces + Codewind in the Kabanero operator. Covers the following: 
- Prerequisites for CodeReady Workspaces + Codewind
- Configuring the Kabanero CR instance to install CodeReady Workspace
    - Optional: Configuring with TLS and OpenShift oAuth
- Creating a Codewind workspace
- Uninstalling Codewind and CodeReady

I've also updated the references of `Spec.codereadyWorkspaces` to `Spec.codeReadyWorkspaces`, as that's the proper value in the Kabanero CR.

@j-c-berger Please review