### PR TITLE
WIP - Avoid using the OpenShift console for editing Kabanero CR

### DIFF
--- a/ref/general/configuration/app-deploy-namespace.adoc
+++ b/ref/general/configuration/app-deploy-namespace.adoc
@@ -40,6 +40,8 @@ spec:
 +
 
 For a full list of supported attributes in a `kabanero.yaml` configuration file, see link:kabanero-cr-config.html[Configuring a Kabanero CR instance].
++
+Note: Avoid using the OpenShift Console to edit the Kabanero CR instance.  The console may change the `apiVersion` of the Kabanero CR instance from `v1alpha2` to `v1alpha1`.  There is a description of the issue link:https://github.com/openshift/console/issues/4444[here].
 
 . Apply your changes to the Kabanero CR instance. For example, to apply changes to the Kabanero CR instance in the `kabanero` namespace, run the following command:
 +

--- a/ref/general/configuration/github-authorization.adoc
+++ b/ref/general/configuration/github-authorization.adoc
@@ -35,3 +35,5 @@ spec:
       - admins
     apiUrl: https://api.github.com
 ```
+
+Note: Avoid using the OpenShift Console to edit the Kabanero CR instance.  The console may change the `apiVersion` of the Kabanero CR instance from `v1alpha2` to `v1alpha1`.  There is a description of the issue link:https://github.com/openshift/console/issues/4444[here].

--- a/ref/general/configuration/kabanero-cr-config.adoc
+++ b/ref/general/configuration/kabanero-cr-config.adoc
@@ -292,3 +292,5 @@ spec:
   cli:
     sessionExpirationSeconds: 1h
 ```
+
+Note: Avoid using the OpenShift Console to edit the Kabanero CR instance.  The console may change the `apiVersion` of the Kabanero CR instance from `v1alpha2` to `v1alpha1`.  There is a description of the issue link:https://github.com/openshift/console/issues/4444[here].

--- a/ref/general/configuration/rhsso.adoc
+++ b/ref/general/configuration/rhsso.adoc
@@ -47,5 +47,7 @@ spec:
 .. set enable to `true`
 .. set adminSecretName to `rhsso-secret`
 .. click **Save**
++
+Note: Avoid using the OpenShift Console to edit the Kabanero CR instance.  The console may change the `apiVersion` of the Kabanero CR instance from `v1alpha2` to `v1alpha1`.  There is a description of the issue link:https://github.com/openshift/console/issues/4444[here].
 
 . The URL to the RHSSO console can be found in the OCP console, in the kabanero project namespace, under networking, in the **sso** route.  Use the values that were supplied in the secret for `username` and `password` to login in to the RHSSO console. 

--- a/ref/general/configuration/stack-install.adoc
+++ b/ref/general/configuration/stack-install.adoc
@@ -17,6 +17,8 @@ link:https://appsody.dev/docs/stacks/publish[Publishing Stacks], follow these st
 * Replace `<release>` with the name of the release that was created
 
 . Find the name of your Kabanero CR instance.  Use `oc get kabaneros -n kabanero` to obtain a list of all Kabanero CR instances in namespace `kabanero`.  The default name for the CR instance is `kabanero`.  Then, edit the specific CR instance using `oc edit kabanero <name> -n kabanero`, replacing `<name>` with the instance name.
++
+Note: Avoid using the OpenShift Console to edit the Kabanero CR instance.  The console may change the `apiVersion` of the Kabanero CR instance from `v1alpha2` to `v1alpha1`.  There is a description of the issue link:https://github.com/openshift/console/issues/4444[here].
 
 . Modify your Kabanero CR instance to target the new stacks that were pushed to the remote GitHub repository and the teams in GitHub that will administer the stacks.  Specifically:
 * The `Spec.Stacks.Repositories.Https.url` attribute should be set to the URL of the alternative stack repository.

--- a/ref/general/reference/troubleshooting.adoc
+++ b/ref/general/reference/troubleshooting.adoc
@@ -148,6 +148,10 @@ If the data does not show a `Ready` state and the problem is persistent, there m
    - Use the `oc get kservice -n tekton-pipelines` command.
    - If the `webhooks-extension-sink` KService is not in the `Ready` state, delete a revision object that is associated with the `webhooks-extension-sink`. For example, use the `oc delete rev -l serving.knative.dev/configuration=webhooks-extension-sink` command.
 
+== Changes to Kabanero CR instance are not persisted
+
+Avoid using the OpenShift Console to edit the Kabanero CR instance.  The console may change the `apiVersion` of the Kabanero CR instance from `v1alpha2` to `v1alpha1`.  The fields of the Kabanero CR instance which were not defined in the `v1alpha` version may be deleted.  There is a description of the issue link:https://github.com/openshift/console/issues/4444[here].
+
 == Debugging subcomponents
 
 You can use the `oc get` or the `oc describe` command to obtain the status of the subcomponents for the product operator.


### PR DESCRIPTION
See openshift/console#4444.  We're trying to steer people away from using the OpenShift console when editing their Kabanero CR instances, due to its perceived tendency to prefer the v1alpha1 version of the Kabanero CRD.  

If anything, this PR should show where the places are in the Kabanero doc that need to be changed.  How we tell people to stop using the console is up for discussion.

@jantley-ibm @tam512 