### PR TITLE
Fix the pipeline logs command

### DIFF
--- a/ref/general/installation/installing-kabanero-foundation.adoc
+++ b/ref/general/installation/installing-kabanero-foundation.adoc
@@ -121,7 +121,7 @@ You can build and deploy a simple java-microprofile application using the defaul
 * By default, the application container image is built and pushed to the Internal Registry, and then deployed serverless
 
 . (Optional) Access the pipeline logs
-* `oc logs $(oc get pods -l tekton.dev/pipelineRun=appsody-manual-pipeline-run --output=jsonpath={.items[0].metadata.name}) --all-containers`
+* `oc logs $(oc get pods -l tekton.dev/pipelineRun=java-microprofile-manual-pipeline-run -n kabanero --output="jsonpath={.items[0].metadata.name}") -n kabanero --all-containers`
 
 . (Optional) Make detailed pipeline changes by accessing the pipelines dashboard
 * `http://tekton-dashboard.<MY_OPENSHIFT_MASTER_DEFAULT_SUBDOMAIN>`


### PR DESCRIPTION
There are several things wrong with the command to access the pipeline logs:
- the pipelineRun name does not match what was in the `example-tekton-pipeline-run.sh` script
- the namespace needs to be specified
- quotes need to surround the output option's value (at least for zsh users)