### PR TITLE
Add information for configuring GHE assets

### DIFF
--- a/ref/general/configuration/ghe-credentials.adoc
+++ b/ref/general/configuration/ghe-credentials.adoc
@@ -1,0 +1,70 @@
+:page-layout: doc
+:page-doc-category: Configuration
+:page-title: Specifying Credentials to Access GitHub Enterprise Resources
+:linkattrs:
+:sectanchors:
+= Specifying Credentials to Access GitHub Enterprise Resources
+
+The Kabanero CR instance can be configured to access stack indexes and pipeline zips that are contained within a protected GitHub release.  A GitHub Personal Access Token (PAT) is required, and must be stored within a `Secret` in the same namespace as the Kabanero CR instance.
+
+. Generate a GitHub Personal Access Token (PAT) with sufficient privileges (scope) to read the GitHub release assets that you require.  Typically the `read:org` scope is appropriate.
+
+. Define a `Secret` containing the PAT that will be used to access the GitHub release.  The PAT should be provided in the `data` section, with a key named `password`.  The secret must also contain an annotation which associates it with the hostname where the GitHub release exists.  The format of the annotation is `kabanero.io/git-0: https://hostname` where `hostname` is replaced with the GitHub hostname.  For example, the following yaml defines a secret that is used to access GitHub releases on github.mydomain.com:
++
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-user-pass
+  annotations:
+    kabanero.io/git-0: https://github.mydomain.com
+type: kubernetes.io/basic-auth
+stringData:
+  password: <PAT>
+```
++
+For more information about how Kabanero uses this secret, read the notes at the end of this page.
+
+. Modify your Kabanero CR instance to refer to the stack index, or pipeline zip, contained in a GitHub release.  The release information is specified in the `gitRelease` field of the Kabanero CR instance.  This field is mutually exclusive with the `https` field, which is used to specify an unprotected URL.  For example, the default stack index for Kabanero 0.6.0 could be specified in the following way (note that this release is unprotected):
++
+```yaml
+apiVersion: kabanero.io/v1alpha2
+kind: Kabanero
+metadata:
+  name: kabanero
+  namespace: kabanero
+spec:
+  version: "0.6.0"
+  stacks: 
+    repositories: 
+    - name: central
+      gitRelease:
+        hostname: "github.com"
+        organization: "kabanero-io"
+        project: "kabanero-stack-hub"
+        release: "0.6.0"
+        assetName: "kabanero-stack-hub-index.yaml"
+```
+
+. The Kabanero operator will search for a secret where the `kabanero.io/git-0` annotation matches the `hostname` defined in the Kabanero CR instance.  If a match is found, the PAT contained within the secret is used to retrieve the asset from the GitHub release.
+
+=== Notes about credential selection
+
+In the unlikely event that the same PAT should be used for more than one hostname, multiple annotations can be added to the secret.  For example, if the same PAT should be used for both `github.mydomain.com` and `github.otherdomain.com`, the following annotations are valid:
+
+```yaml
+metadata:
+  name: basic-user-pass
+  annotations:
+    kabanero.io/git-0: https://github.mydomain.com
+    kabanero.io/git-1: https://github.otherdomain.com
+```
+
+If more than one Secret matches a given hostname, the one with the lexically lowest key (kabanero.io/git-*) is used.
+
+The example above shows how to access a stack hub index.  The same approach is used to access pipeline zips, by replacing the `https` field in the pipeline specification, with the `gitRelease` field.
+
+
+== Need help?
+If you have questions, we would like to hear from you.
+You can reach out to the community for assistance on the https://ibm-cloud-tech.slack.com/messages/CJZCYTD0Q[Kabanero Slack channel, window="_blank"].

--- a/ref/general/configuration/ghe-credentials.adoc
+++ b/ref/general/configuration/ghe-credentials.adoc
@@ -34,7 +34,7 @@ metadata:
   name: kabanero
   namespace: kabanero
 spec:
-  version: "0.6.0"
+  version: "0.7.0"
   stacks: 
     repositories: 
     - name: central
@@ -42,11 +42,13 @@ spec:
         hostname: "github.com"
         organization: "kabanero-io"
         project: "kabanero-stack-hub"
-        release: "0.6.0"
+        release: "0.7.0"
         assetName: "kabanero-stack-hub-index.yaml"
 ```
 
 . The Kabanero operator will search for a secret where the `kabanero.io/git-0` annotation matches the `hostname` defined in the Kabanero CR instance.  If a match is found, the PAT contained within the secret is used to retrieve the asset from the GitHub release.
+
+The example above shows how to access a stack hub index.  The same approach is used to access pipeline zips, by replacing the `https` field in the pipeline specification, with the `gitRelease` field.
 
 === Notes about credential selection
 
@@ -61,8 +63,6 @@ metadata:
 ```
 
 If more than one Secret matches a given hostname, the one with the lexically lowest key (kabanero.io/git-*) is used.
-
-The example above shows how to access a stack hub index.  The same approach is used to access pipeline zips, by replacing the `https` field in the pipeline specification, with the `gitRelease` field.
 
 
 == Need help?

--- a/ref/general/configuration/kabanero-cr-config.adoc
+++ b/ref/general/configuration/kabanero-cr-config.adoc
@@ -49,16 +49,30 @@ specify the following fields:
 **** `Sha256` - The digest of the pipelines contained at this
       URL.  Typically a command like `sha256sum` is used to obtain the
       digest.
-**** `https`
+**** `https` - Used for accessing pipelines via an unprotected URL.
+      This field is mutually exclusive with the `gitRelease` field.
 ***** `url` - The URL pointing to the pipelines.  Typically this file
        has a `.tar.gz` extension.  The URL will be accessed using
        HTTPS.
 ***** `skipCertVerification` - Controls whether the Kabanero controller will
        validate SSL/TLS certificates presented by the pipelines URL.
        Valid values are `true` and `false`.
+**** `gitRelease` - Used for accessing pipelines via a protected GitHub
+     release.  This field is mutually exclusive with the `https` field.
+     Login credentials must be supplied - see link:ghe-credentials.html[Specifying Credentials to Access Protected GitHub Resources].
+***** `hostname` - The host name where the GitHub release exists.
+***** `organization` - The user name, or organization name, where the
+      GitHub release exists.
+***** `project` - The project where the GitHub release exists.
+***** `release` - The name of the release within the GitHub project.
+***** `assetName` - The name of the file (asset) within the release.
+***** `skipCertVerification` - Controls whether the Kabanero controller will
+       validate SSL/TLS certificates presented by the pipelines URL.
+       Valid values are `true` and `false`.
 *** `repositories` - A list of repositories containing application stacks.
 **** `name` - A descriptive name of the stack repository.
-**** `https`
+**** `https` - Used for accessing a stack index via an unprotected URL.
+     This field is mutually exclusive with the `gitRelease` field.
 ***** `url` - The URL pointing to the stack repository.  The URL will
       be accessed using HTTPS.  For example, the 
       default stack repository for Kabanero version 0.5.0 is
@@ -66,16 +80,41 @@ specify the following fields:
 ***** `skipCertVerification` - Controls whether the Kabanero controller will
       validate SSL/TLS certificates presented by the repository URL.
       Valid values are `true` and `false`.
+**** `gitRelease` - Used for accessing a stack index via a protected GitHub
+     release.  This field is mutually exclusive with the `https` field.
+     Login credentials must be supplied - see link:ghe-credentials.html[Specifying Credentials to Access Protected GitHub Resources].
+***** `hostname` - The host name where the GitHub release exists.
+***** `organization` - The user name, or organization name, where the
+      GitHub release exists.
+***** `project` - The project where the GitHub release exists.
+***** `release` - The name of the release within the GitHub project.
+***** `assetName` - The name of the file (asset) within the release.
+***** `skipCertVerification` - Controls whether the Kabanero controller will
+       validate SSL/TLS certificates presented by the pipelines URL.
+       Valid values are `true` and `false`.
 **** `pipelines` - A list of pipelines that should be applied to the
       stacks in this repository.
 ***** `id` - A descriptive name of the pipelines contained at this URL.
 ***** `Sha256` - The digest of the pipelines contained at this
       URL.  Typically a command like `sha256sum` is used to obtain the
       digest.
-***** `https`
+***** `https` - Used for accessing pipelines via an unprotected GitHub
+      release.  This field is mutually exclusive with the `gitRelease` field.
 ****** `url` - The URL pointing to the pipelines.  Typically this file
        has a `.tar.gz` extension.  The URL will be accessed using
        HTTPS.
+****** `skipCertVerification` - Controls whether the Kabanero controller will
+       validate SSL/TLS certificates presented by the pipelines URL.
+       Valid values are `true` and `false`.
+***** `gitRelease` - Used for accessing pipelines via a protected GitHub
+      release.  This field is mutually exclusive with the `https` field.
+      Login credentials must be supplied - see link:ghe-credentials.html[Specifying Credentials to Access Protected GitHub Resources].
+****** `hostname` - The host name where the GitHub release exists.
+****** `organization` - The user name, or organization name, where the
+       GitHub release exists.
+****** `project` - The project where the GitHub release exists.
+****** `release` - The name of the release within the GitHub project.
+****** `assetName` - The name of the file (asset) within the release.
 ****** `skipCertVerification` - Controls whether the Kabanero controller will
        validate SSL/TLS certificates presented by the pipelines URL.
        Valid values are `true` and `false`.
@@ -283,6 +322,37 @@ spec:
     - name: central
       https: 
         url: https://github.com/my-organization/stacks/releases/download/v0.1/kabanero-index.yaml
+  github:
+    organization: my-organization
+    teams:
+      - stack-admins
+      - admins
+    apiUrl: https://api.github.com
+  cli:
+    sessionExpirationSeconds: 1h
+```
+
+This example yaml defines a `Kabanero` instance at version 0.6.0, using
+the same custom stacks as the previous example, but using the `gitRelease`
+field instead of the `https` field:
+
+```yaml
+apiVersion: kabanero.io/v1alpha2
+kind: Kabanero
+metadata:
+  name: kabanero
+  namespace: kabanero
+spec:
+  version: "0.6.0"
+  stacks:
+    repositories:
+    - name: central
+      gitRelease:
+        hostname: "github.com"
+        organization: "my-organization"
+        project: "stacks"
+        release: "v0.1"
+        assetName: "kabanero-index.yaml"
   github:
     organization: my-organization
     teams:

--- a/ref/general/configuration/kabanero-cr-config.adoc
+++ b/ref/general/configuration/kabanero-cr-config.adoc
@@ -50,7 +50,9 @@ specify the following fields:
       URL.  Typically a command like `sha256sum` is used to obtain the
       digest.
 **** `https` - Used for accessing pipelines via an unprotected URL.
-      This field is mutually exclusive with the `gitRelease` field.
+      This field is mutually exclusive with the `gitRelease` field.  If
+      both `https` and `gitRelease` are specified, the values in
+      `gitRelease` are used.
 ***** `url` - The URL pointing to the pipelines.  Typically this file
        has a `.tar.gz` extension.  The URL will be accessed using
        HTTPS.
@@ -59,7 +61,9 @@ specify the following fields:
        Valid values are `true` and `false`.
 **** `gitRelease` - Used for accessing pipelines via a protected GitHub
      release.  This field is mutually exclusive with the `https` field.
-     Login credentials must be supplied - see link:ghe-credentials.html[Specifying Credentials to Access Protected GitHub Resources].
+     If both `https` and `gitRelease` are specified, the values in
+     `gitRelease` are used. Login credentials must be supplied - see
+     link:ghe-credentials.html[Specifying Credentials to Access Protected GitHub Resources].
 ***** `hostname` - The host name where the GitHub release exists.
 ***** `organization` - The user name, or organization name, where the
       GitHub release exists.
@@ -72,7 +76,9 @@ specify the following fields:
 *** `repositories` - A list of repositories containing application stacks.
 **** `name` - A descriptive name of the stack repository.
 **** `https` - Used for accessing a stack index via an unprotected URL.
-     This field is mutually exclusive with the `gitRelease` field.
+     This field is mutually exclusive with the `gitRelease` field.  If
+     both `https` and `gitRelease` are specified, the values in
+     `gitRelease` are used.
 ***** `url` - The URL pointing to the stack repository.  The URL will
       be accessed using HTTPS.  For example, the 
       default stack repository for Kabanero version 0.5.0 is
@@ -81,8 +87,10 @@ specify the following fields:
       validate SSL/TLS certificates presented by the repository URL.
       Valid values are `true` and `false`.
 **** `gitRelease` - Used for accessing a stack index via a protected GitHub
-     release.  This field is mutually exclusive with the `https` field.
-     Login credentials must be supplied - see link:ghe-credentials.html[Specifying Credentials to Access Protected GitHub Resources].
+     release.  This field is mutually exclusive with the `https` field. If
+     both `https` and `gitRelease` are specified, the values in
+     `gitRelease` are used.  Login credentials must be supplied - see
+     link:ghe-credentials.html[Specifying Credentials to Access Protected GitHub Resources].
 ***** `hostname` - The host name where the GitHub release exists.
 ***** `organization` - The user name, or organization name, where the
       GitHub release exists.
@@ -100,6 +108,8 @@ specify the following fields:
       digest.
 ***** `https` - Used for accessing pipelines via an unprotected GitHub
       release.  This field is mutually exclusive with the `gitRelease` field.
+      If both `https` and `gitRelease` are specified, the values in
+      `gitRelease` are used.
 ****** `url` - The URL pointing to the pipelines.  Typically this file
        has a `.tar.gz` extension.  The URL will be accessed using
        HTTPS.
@@ -107,8 +117,10 @@ specify the following fields:
        validate SSL/TLS certificates presented by the pipelines URL.
        Valid values are `true` and `false`.
 ***** `gitRelease` - Used for accessing pipelines via a protected GitHub
-      release.  This field is mutually exclusive with the `https` field.
-      Login credentials must be supplied - see link:ghe-credentials.html[Specifying Credentials to Access Protected GitHub Resources].
+      release.  This field is mutually exclusive with the `https` field.  If
+      both `https` and `gitRelease` are specified, the values in
+      `gitRelease` are used.  Login credentials must be supplied - see
+      link:ghe-credentials.html[Specifying Credentials to Access Protected GitHub Resources].
 ****** `hostname` - The host name where the GitHub release exists.
 ****** `organization` - The user name, or organization name, where the
        GitHub release exists.
@@ -287,7 +299,7 @@ replace `-n kabanero` with the name of another namespace.
 
 == Examples
 
-This example yaml defines a `Kabanero` instance at version 0.6.0, using
+This example yaml defines a `Kabanero` instance at version 0.7.0, using
 the default stacks.
 
 ```yaml
@@ -297,15 +309,15 @@ metadata:
   name: kabanero
   namespace: kabanero
 spec:
-  version: "0.6.0"
+  version: "0.7.0"
   stacks:
     repositories:
     - name: central
       https:
-        url: https://github.com/kabanero-io/collections/releases/download/v0.6.0/kabanero-index.yaml
+        url: https://github.com/kabanero-io/kabanero-stack-hub/releases/download/0.7.0/kabanero-stack-hub-index.yaml
 ```
 
-This example yaml defines a `Kabanero` instance at version 0.6.0, using
+This example yaml defines a `Kabanero` instance at version 0.7.0, using
 custom stacks and their associated GitHub configuration.  Sessions
 established using the Kabanero CLI remain valid for one hour.
 
@@ -316,7 +328,7 @@ metadata:
   name: kabanero
   namespace: kabanero
 spec:
-  version: "0.6.0"
+  version: "0.7.0"
   stacks:
     repositories:
     - name: central
@@ -332,7 +344,7 @@ spec:
     sessionExpirationSeconds: 1h
 ```
 
-This example yaml defines a `Kabanero` instance at version 0.6.0, using
+This example yaml defines a `Kabanero` instance at version 0.7.0, using
 the same custom stacks as the previous example, but using the `gitRelease`
 field instead of the `https` field:
 
@@ -343,7 +355,7 @@ metadata:
   name: kabanero
   namespace: kabanero
 spec:
-  version: "0.6.0"
+  version: "0.7.0"
   stacks:
     repositories:
     - name: central

--- a/ref/general/configuration/stack-cr-config.adoc
+++ b/ref/general/configuration/stack-cr-config.adoc
@@ -39,7 +39,9 @@ specify the following fields:
       URL.  Typically a command like `sha256sum` is used to obtain the
       digest.
 **** `https` - Used for accessing pipelines via an unprotected URL.
-     This field is mutually exclusive with the `gitRelease` field.
+     This field is mutually exclusive with the `gitRelease` field.  If
+     both `https` and `gitRelease` are specified, the values in
+     `gitRelease` are used.
 ***** `url` - The URL pointing to the pipelines.  Typically this file
        has a `.tar.gz` extension.  The URL will be accessed using
        HTTPS.
@@ -47,8 +49,10 @@ specify the following fields:
        validate SSL/TLS certificates presented by the pipelines URL.
        Valid values are `true` and `false`.
 **** `gitRelease` - Used for accessing pipelines via a protected GitHub
-      release.  This field is mutually exclusive with the `https` field.
-      Login credentials must be supplied - see link:ghe-credentials.html[Specify
+      release.  This field is mutually exclusive with the `https` field.  If
+      both `https` and `gitRelease` are specified, the values in
+      `gitRelease` are used.  Login credentials must be supplied - see
+      link:ghe-credentials.html[Specify
 ***** `hostname` - The host name where the GitHub release exists.
 ***** `organization` - The user name, or organization name, where the
        GitHub release exists.

--- a/ref/general/configuration/stack-cr-config.adoc
+++ b/ref/general/configuration/stack-cr-config.adoc
@@ -38,11 +38,24 @@ specify the following fields:
 **** `Sha256` - The digest of the pipelines contained at this
       URL.  Typically a command like `sha256sum` is used to obtain the
       digest.
-**** `https`
+**** `https` - Used for accessing pipelines via an unprotected URL.
+     This field is mutually exclusive with the `gitRelease` field.
 ***** `url` - The URL pointing to the pipelines.  Typically this file
        has a `.tar.gz` extension.  The URL will be accessed using
        HTTPS.
 ***** `skipCertVerification` - Controls whether the stack controller will
+       validate SSL/TLS certificates presented by the pipelines URL.
+       Valid values are `true` and `false`.
+**** `gitRelease` - Used for accessing pipelines via a protected GitHub
+      release.  This field is mutually exclusive with the `https` field.
+      Login credentials must be supplied - see link:ghe-credentials.html[Specify
+***** `hostname` - The host name where the GitHub release exists.
+***** `organization` - The user name, or organization name, where the
+       GitHub release exists.
+***** `project` - The project where the GitHub release exists.
+***** `release` - The name of the release within the GitHub project.
+***** `assetName` - The name of the file (asset) within the release.
+***** `skipCertVerification` - Controls whether the Kabanero controller will
        validate SSL/TLS certificates presented by the pipelines URL.
        Valid values are `true` and `false`.
 *** `images` - A list of container images that are associated with
@@ -80,6 +93,29 @@ spec:
         - https:
             url: >-
               https://github.com/kabanero-io/collections/releases/download/0.5.0/incubator.common.pipeline.default.tar.gz
+          id: default
+          sha256: 14285a7f0bb152759b3e2141db19d72ea1f94f01bbf5ffbf866cab4e60e093dd
+      version: 0.2.21
+```
+
+This example is the same as the previous example, except uses the `gitRelease` field to specify the Pipelines zip:
+
+```yaml
+apiVersion: kabanero.io/v1alpha2
+kind: Stack
+metadata:
+  name: java-microprofile
+  namespace: kabanero
+spec:
+  name: java-microprofile
+  versions:
+    - pipelines:
+        - gitRelease:
+            hostname: "github.com"
+            organization: "kabanero-io"
+            project: "collections"
+            release: "0.5.0"
+            assetName: "incubator.common.pipeline.default.tar.gz"
           id: default
           sha256: 14285a7f0bb152759b3e2141db19d72ea1f94f01bbf5ffbf866cab4e60e093dd
       version: 0.2.21

--- a/ref/general/configuration/stack-install.adoc
+++ b/ref/general/configuration/stack-install.adoc
@@ -52,7 +52,7 @@ spec:
     apiUrl: https://api.github.com
 ```
 +
-If the GitHub repsitory is protected, see link:ghe-credentials.html[Specifying Credentials to Access Protected GitHub Resources].  For more information about other fields that can be customized in the Kabanero CR instance, see link:kabanero-cr-config.html[Configuring a Kabanero CR instance].
+If the GitHub repository is protected, see link:ghe-credentials.html[Specifying Credentials to Access Protected GitHub Resources].  For more information about other fields that can be customized in the Kabanero CR instance, see link:kabanero-cr-config.html[Configuring a Kabanero CR instance].
 +
 After editing, save your changes.  The updated Kabanero CR instance is applied to your cluster.
 

--- a/ref/general/configuration/stack-install.adoc
+++ b/ref/general/configuration/stack-install.adoc
@@ -52,7 +52,7 @@ spec:
     apiUrl: https://api.github.com
 ```
 +
-For more information about other fields that can be customized in the Kabanero CR instance, see link:kabanero-cr-config.html[Configuring a Kabanero CR instance].
+If the GitHub repsitory is protected, see link:ghe-credentials.html[Specifying Credentials to Access Protected GitHub Resources].  For more information about other fields that can be customized in the Kabanero CR instance, see link:kabanero-cr-config.html[Configuring a Kabanero CR instance].
 +
 After editing, save your changes.  The updated Kabanero CR instance is applied to your cluster.
 


### PR DESCRIPTION
Users can now access stack hub indexes and pipeline zips that are protected by GitHub in a private repository, or by GHE.  This documentation explains how to configure the Kabanero CR instance to do that.

@mezarin would you please review this from a technical perspective?
This will also need an ID review.