### PR TITLE
tell users to config cli before config Console OAuth 

### DIFF
--- a/ref/general/configuration/console-oauth.adoc
+++ b/ref/general/configuration/console-oauth.adoc
@@ -7,6 +7,8 @@
 
 You can enable optional stack management features via the product console by configuring GitHub OAuth. This setup will allow the console to verify users via GitHub OAuth.
 
+. The stack management features communicate with the CLI server so it's important to link:/docs/ref/general/configuration/github-authorization.html[configure the CLI service with authorization] before you continue.
+
 . From your GitHub organization page, create an OAuth Application in **Settings -> OAuth App -> New OAuth Apps**. Note: the OAuth GitHub app will need to be created in the same GitHub organization that your stack hub is in. If the OAuth GitHub app and the stack hub repository **need** to be in different GitHub orgs, then the OAuth GitHub app can request access to data in the org with the application stacks. For more information see the GitHub doc - https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-oauth-app-access-restrictions[OAuth App Access and Restrictions].
 
     * `Application name` can be anything, a suggestion is: `kabanero console`.

--- a/ref/general/configuration/console-oauth.adoc
+++ b/ref/general/configuration/console-oauth.adoc
@@ -7,7 +7,7 @@
 
 You can enable optional stack management features via the product console by configuring GitHub OAuth. This setup will allow the console to verify users via GitHub OAuth.
 
-. The stack management features communicate with the CLI server so it's important to link:/docs/ref/general/configuration/github-authorization.html[configure the CLI service with authorization] before you continue.
+. The stack management features communicate with the CLI server. Therefore, link:/docs/ref/general/configuration/github-authorization.html[configure the CLI service with authorization] before you continue.
 
 . From your GitHub organization page, create an OAuth Application in **Settings -> OAuth App -> New OAuth Apps**. Note: the OAuth GitHub app will need to be created in the same GitHub organization that your stack hub is in. If the OAuth GitHub app and the stack hub repository **need** to be in different GitHub orgs, then the OAuth GitHub app can request access to data in the org with the application stacks. For more information see the GitHub doc - https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-oauth-app-access-restrictions[OAuth App Access and Restrictions].
 


### PR DESCRIPTION
we need people to know they must update the CRD with the GitHub spec before OAuth can work properly.

The CLI service authorization is technically a prerequisite.