### PR TITLE
Fixed broken link for 0.7.0

### DIFF
--- a/ref/general/installation/installing-codeready-and-codewind.adoc
+++ b/ref/general/installation/installing-codeready-and-codewind.adoc
@@ -75,7 +75,7 @@ When CodeReady Workspaces is installed on your OpenShift cluster, complete the f
 
 CodeReady Workspaces starts Codewind and installs the Codewind plugins. This process might take a couple of minutes for all of the necessary components to be pulled and started.
 
-Consult the https://www.eclipse.org/codewind/mdt-che-overview.html[Codewind on Che documentation, window="_blank"] for additional information and next steps.
+Consult the https://www.eclipse.org/codewind/mdt-che-installinfo.html[Codewind on Che documentation, window="_blank"] for additional information and next steps.
 
 === Stopping or Uninstalling Codewind
 If you need to stop the Codewind workspace, follow these steps:


### PR DESCRIPTION
Signed-off-by: Jacob Berger <jacob.berger@ibm.com>

@SueChaplain or @jantley-ibm please review this change for the broken link in our `installing codeready and codewind` doc. This PR is made on the 0.7.0 branch. 

I made a similar PR, #363 for the 0.8.0 branch. 

Once this PR is approved and merged, I can ask Andrew to run another build and update the website. thanks! 