### PR TITLE
Add new Kabanero Operator CR spec entry.

### DIFF
--- a/ref/general/configuration/kabanero-cr-config.adoc
+++ b/ref/general/configuration/kabanero-cr-config.adoc
@@ -132,7 +132,7 @@ specify the following fields:
        Valid values are `true` and `false`.
 *** `skipRegistryCertVerification` - Controls whether the controller will
        validate SSL/TLS certificates presented by the registry hosting the
-       stack container image from which the controller tries to read information.
+       stack's container image.
        Valid values are `true` and `false`.
 ** `cliServices`
 *** `sessionExpirationSeconds` - The length of time (duration) that

--- a/ref/general/configuration/kabanero-cr-config.adoc
+++ b/ref/general/configuration/kabanero-cr-config.adoc
@@ -98,7 +98,7 @@ specify the following fields:
 ***** `release` - The name of the release within the GitHub project.
 ***** `assetName` - The name of the file (asset) within the release.
 ***** `skipCertVerification` - Controls whether the controller will
-       validate SSL/TLS certificates presented by the pipelines URL.
+       validate SSL/TLS certificates presented by the repository URL.
        Valid values are `true` and `false`.
 **** `pipelines` - A list of pipelines that should be applied to the
       stacks in this repository.
@@ -129,6 +129,10 @@ specify the following fields:
 ****** `assetName` - The name of the file (asset) within the release.
 ****** `skipCertVerification` - Controls whether the controller will
        validate SSL/TLS certificates presented by the pipelines URL.
+       Valid values are `true` and `false`.
+*** `skipRegistryCertVerification` - Controls whether the controller will
+       validate SSL/TLS certificates presented by the registry hosting the
+       stack container image from which the controller tries to read information.
        Valid values are `true` and `false`.
 ** `cliServices`
 *** `sessionExpirationSeconds` - The length of time (duration) that

--- a/ref/general/configuration/stack-cr-config.adoc
+++ b/ref/general/configuration/stack-cr-config.adoc
@@ -32,6 +32,10 @@ specify the following fields:
     the stack index which caused this Stack CR to be created.
     This behavior can be used to permanently activate or deactivate
     a stack, until the configuration is manually changed.
+*** `skipRegistryCertVerification` - Controls whether the controller will
+       validate SSL/TLS certificates presented by the registry hosting the
+       stack's container image.
+       Valid values are `true` and `false`.
 *** `pipelines` - A list of pipelines which should be applied to
     this stack version.
 **** `id` - A descriptive name of the pipelines contained at this URL.


### PR DESCRIPTION
For 0.8.0, the Kabanero CR instance contains a new spec.stacks.skipRegistryCertVerification entry that needs to be documented.