### PR TITLE
Removes Onboard from kab-doc

### DIFF
--- a/ref/general/reference/kabanero-cli.adoc
+++ b/ref/general/reference/kabanero-cli.adoc
@@ -68,22 +68,6 @@ Complete list of flags:
 -u, --username string             GitHub username
 ----
 
-=== Onboard a developer
-
-Run the `kabanero onboard` command to onboard a developer.
-
-----
-kabanero onboard <GITHUB_USER_ID>
-----
-
-This command is under development.
-
-Example result:
-
-----
-Go to the pipelines dashboard at <tekton-url> in your browser and manually configure the webhook for gituser: <GITHUB_USER_ID>
-----
-
 === List application stacks
 
 Run the `kabanero list` command to list all the application stacks in a kabanero instance, along with their status.

--- a/ref/general/reference/kabanero-cli.adoc
+++ b/ref/general/reference/kabanero-cli.adoc
@@ -68,6 +68,11 @@ Complete list of flags:
 -u, --username string             GitHub username
 ----
 
+=== Onboard a developer (Removed)
+
+The `kabanero onboard` command was removed and is not available in this release.
+
+
 === List application stacks
 
 Run the `kabanero list` command to list all the application stacks in a kabanero instance, along with their status.


### PR DESCRIPTION
Onboard is no longer a command in 0.9.0
https://github.com/kabanero-io/kabanero-command-line/pull/235